### PR TITLE
Fix key warnings

### DIFF
--- a/src/app/Explore/Explore.tsx
+++ b/src/app/Explore/Explore.tsx
@@ -336,27 +336,21 @@ export const Explore: React.FC = () => {
                             name: string;
                             source: StructDef;
                           }[];
-                          return (
-                            <>
-                              {sources.map((entry) => {
-                                return (
-                                  <SourceLink
-                                    key={entry.name}
-                                    onClick={() => {
-                                      setDatasetSource(dataset, entry.name);
-                                    }}
-                                  >
-                                    <SourceLinkTitleRow>
-                                      {snakeToTitle(entry.name)}
-                                    </SourceLinkTitleRow>
-                                    <SourceLinkDescription>
-                                      In {dataset.name}
-                                    </SourceLinkDescription>
-                                  </SourceLink>
-                                );
-                              })}
-                            </>
-                          );
+                          return sources.map((entry) => (
+                            <SourceLink
+                              key={entry.name}
+                              onClick={() => {
+                                setDatasetSource(dataset, entry.name);
+                              }}
+                            >
+                              <SourceLinkTitleRow>
+                                {snakeToTitle(entry.name)}
+                              </SourceLinkTitleRow>
+                              <SourceLinkDescription>
+                                In {dataset.name}
+                              </SourceLinkDescription>
+                            </SourceLink>
+                          ));
                         })}
                     </DatasetsWrapperInner>
                   </DatasetsWrapperOuter>

--- a/src/app/SelectDropdown/SelectDropdown.tsx
+++ b/src/app/SelectDropdown/SelectDropdown.tsx
@@ -155,24 +155,25 @@ export function SelectList<T>({
 }: SelectListProps<T>): JSX.Element {
   return (
     <SelectListDiv>
-      {options.map((option, index) => {
+      {options.reduce<JSX.Element[]>((result, option, index) => {
         const isSelected =
           value !== undefined && valueEqual(value, option.value);
-        return (
-          <>
-            {option.divider && <OptionDivider key={"divider" + index} />}
-            <OptionDiv
-              key={index}
-              onClick={() => onChange(option.value)}
-              className={isSelected ? "selected" : ""}
-            >
-              <OptionRadio type="radio" defaultChecked={isSelected} />
-              <CheckIcon className={isSelected ? "selected" : ""} />
-              <OptionSpan>{option.label}</OptionSpan>
-            </OptionDiv>
-          </>
+        if (option.divider) {
+          result.push(<OptionDivider key={"divider" + index} />);
+        }
+        result.push(
+          <OptionDiv
+            key={index}
+            onClick={() => onChange(option.value)}
+            className={isSelected ? "selected" : ""}
+          >
+            <OptionRadio type="radio" defaultChecked={isSelected} />
+            <CheckIcon className={isSelected ? "selected" : ""} />
+            <OptionSpan>{option.label}</OptionSpan>
+          </OptionDiv>
         );
-      })}
+        return result;
+      }, [])}
     </SelectListDiv>
   );
 }
@@ -188,14 +189,17 @@ interface DropdownMenuProps {
 export function DropdownMenu({ options }: DropdownMenuProps): JSX.Element {
   return (
     <SelectListDiv>
-      {options.map((option, index) => (
-        <>
-          {option.divider && <OptionDivider key={"divider" + index} />}
+      {options.reduce<JSX.Element[]>((result, option, index) => {
+        if (option.divider) {
+          result.push(<OptionDivider key={"divider" + index} />);
+        }
+        result.push(
           <OptionDiv key={index} onClick={() => option.onSelect()}>
             <OptionSpan>{option.label}</OptionSpan>
           </OptionDiv>
-        </>
-      ))}
+        );
+        return result;
+      }, [])}
     </SelectListDiv>
   );
 }


### PR DESCRIPTION
React doesn't like using fragments as list elements, because you can't assign them keys. This was giving us the `react_devtools_backend.js:4026 Warning: Each child in a list should have a unique "key" prop.` error in a few places. In one place the fragment turned out to be not necessary, but I got a little creative with the dividers.