### PR TITLE
Fix a sloppy merge at d581d6ea

### DIFF
--- a/src/app/Explore/Explore.tsx
+++ b/src/app/Explore/Explore.tsx
@@ -282,6 +282,8 @@ export const Explore: React.FC = () => {
         urlParams.delete("renderer");
         urlParams.set("styles", JSON.stringify(styles));
       }
+      runQuery();
+      setParams(urlParams);
     } catch (error) {
       setError(error);
     }


### PR DESCRIPTION
Sloppy merge in https://github.com/malloydata/malloy-composer/commit/d581d6ea7f7b5bdd570da9f33aab4c3007bf48b6# caused 

```
runQuery();
setParams(urlParams);
```

To be erroneously removed (part of the code for running a query link). These are important... oops!