### PR TITLE
Prevent accidental form submissions

### DIFF
--- a/src/app/AddFilter/AddFilter.tsx
+++ b/src/app/AddFilter/AddFilter.tsx
@@ -170,7 +170,7 @@ export const AddFilter: React.FC<AddFilterProps> = ({
           />
         )}
         <RightButtonRow style={{ padding: "0 15px 15px 15px" }}>
-          <Button color="secondary" onClick={() => onComplete()}>
+          <Button type="button" color="secondary" onClick={onComplete}>
             Cancel
           </Button>
           <Button

--- a/src/app/AddLimit/AddLimit.tsx
+++ b/src/app/AddLimit/AddLimit.tsx
@@ -42,7 +42,7 @@ export const AddLimit: React.FC<LimitContextBarProps> = ({
           autoFocus={true}
           autoSelect={true}
         />{" "}
-        <Button color="secondary" onClick={() => onComplete()}>
+        <Button type="button" color="secondary" onClick={onComplete}>
           Cancel
         </Button>
         <Button

--- a/src/app/AddNewMeasure/AddNewMeasure.tsx
+++ b/src/app/AddNewMeasure/AddNewMeasure.tsx
@@ -192,7 +192,7 @@ export const AddNewMeasure: React.FC<AddMeasureProps> = ({
         </FormFieldList>
         <FormError error={error} />
         <RightButtonRow>
-          <Button color="secondary" onClick={() => onComplete()}>
+          <Button type="button" color="secondary" onClick={onComplete}>
             Cancel
           </Button>
           <Button

--- a/src/app/AddNewNest/AddNewNest.tsx
+++ b/src/app/AddNewNest/AddNewNest.tsx
@@ -41,7 +41,7 @@ export const AddNewNest: React.FC<AddNewNestProps> = ({
           autoFocus={true}
         />
         <RightButtonRow>
-          <Button color="secondary" onClick={() => onComplete()}>
+          <Button type="button" color="secondary" onClick={onComplete}>
             Cancel
           </Button>
           <Button

--- a/src/app/EditFilter/EditFilter.tsx
+++ b/src/app/EditFilter/EditFilter.tsx
@@ -47,7 +47,7 @@ export const EditFilter: React.FC<EditFilterProps> = ({
           autoFocus={true}
         />
         <RightButtonRow>
-          <Button color="secondary" onClick={() => onComplete()}>
+          <Button type="button" color="secondary" onClick={onComplete}>
             Cancel
           </Button>
           <Button

--- a/src/app/EditOrderBy/EditOrderBy.tsx
+++ b/src/app/EditOrderBy/EditOrderBy.tsx
@@ -77,7 +77,7 @@ export const EditOrderBy: React.FC<EditOrderByProps> = ({
           </OptionsRow>
         </FormFieldList>
         <RightButtonRow>
-          <Button color="secondary" onClick={() => onComplete()}>
+          <Button type="button" color="secondary" onClick={onComplete}>
             Cancel
           </Button>
           <Button

--- a/src/app/RenameField/RenameField.tsx
+++ b/src/app/RenameField/RenameField.tsx
@@ -40,7 +40,7 @@ export const RenameField: React.FC<RenameFieldProps> = ({
           placeholder="new_name"
           autoFocus={true}
         />
-        <Button color="secondary" onClick={() => onComplete()}>
+        <Button type="button" color="secondary" onClick={onComplete}>
           Cancel
         </Button>
         <Button

--- a/src/app/ReorderFieldsContextBar/ReorderFieldsContextBar.tsx
+++ b/src/app/ReorderFieldsContextBar/ReorderFieldsContextBar.tsx
@@ -120,7 +120,7 @@ export const ReorderFieldsContextBar: React.FC<
         <EmptyMessage>Query has no fields.</EmptyMessage>
       )}
       <RightButtonRow>
-        <Button color="secondary" onClick={() => onComplete()}>
+        <Button type="button" color="secondary" onClick={onComplete}>
           Cancel
         </Button>
         <Button

--- a/src/app/SelectDropdown/SelectDropdown.tsx
+++ b/src/app/SelectDropdown/SelectDropdown.tsx
@@ -122,8 +122,13 @@ export const SelectDropdown = <T,>({
   return (
     <Wrapper ref={wrapperElement}>
       <InputBox
+        type="button"
         autoFocus={autoFocus}
-        onClick={() => !disabled && setOpen(true)}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          if (!disabled) setOpen(true);
+        }}
       >
         {label}
         <ChevronDown width="22px" height="22px" />


### PR DESCRIPTION
`<button>` elements default to `type="submit"` so form submissions were sometimes randomly firing and reloading the page.