### PR TITLE
Hackily reconstitute filters

### DIFF
--- a/src/app/AddFilter/AddFilter.tsx
+++ b/src/app/AddFilter/AddFilter.tsx
@@ -34,6 +34,7 @@ import { TypeIcon } from "../TypeIcon";
 import { StringFilterBuilder } from "./StringFilterBuilder";
 import {
   BooleanFilter,
+  Filter,
   NumberFilter,
   StringFilter,
   TimeFilter,
@@ -59,6 +60,7 @@ interface AddFilterProps {
   needsRename: boolean;
   onComplete: () => void;
   modelPath: string | undefined;
+  initial?: Filter;
 }
 
 export const AddFilter: React.FC<AddFilterProps> = ({
@@ -70,25 +72,34 @@ export const AddFilter: React.FC<AddFilterProps> = ({
   needsRename,
   onComplete,
   fieldPath,
+  initial,
 }) => {
   const type = typeOfField(field);
   const kind = kindOfField(field);
-  const [stringFilter, setStringFilter] = useState<StringFilter>({
-    type: "is_equal_to",
-    values: [],
-  });
-  const [numberFilter, setNumberFilter] = useState<NumberFilter>({
-    type: "is_equal_to",
-    values: [],
-  });
-  const [timeFilter, setTimeFilter] = useState<TimeFilter>({
-    type: "is_on",
-    date: new Date(),
-    granularity: "day",
-  });
-  const [booleanFilter, setBooleanFilter] = useState<BooleanFilter>({
-    type: "is_true",
-  });
+  const [stringFilter, setStringFilter] = useState<StringFilter>(
+    (type === "string" && (initial as StringFilter)) ?? {
+      type: "is_equal_to",
+      values: [],
+    }
+  );
+  const [numberFilter, setNumberFilter] = useState<NumberFilter>(
+    (type === "number" && (initial as NumberFilter)) ?? {
+      type: "is_equal_to",
+      values: [],
+    }
+  );
+  const [timeFilter, setTimeFilter] = useState<TimeFilter>(
+    ((type === "date" || type === "timestamp") && (initial as TimeFilter)) ?? {
+      type: "is_on",
+      date: new Date(),
+      granularity: "day",
+    }
+  );
+  const [booleanFilter, setBooleanFilter] = useState<BooleanFilter>(
+    (type === "boolean" && (initial as BooleanFilter)) ?? {
+      type: "is_true",
+    }
+  );
   const [filter, setFilter] = useState(
     type === "string"
       ? stringFilterToString(fieldPath, stringFilter)

--- a/src/app/FilterActionMenu/FilterActionMenu.tsx
+++ b/src/app/FilterActionMenu/FilterActionMenu.tsx
@@ -11,16 +11,27 @@
  * GNU General Public License for more details.
  */
 
-import { FilterExpression, StructDef } from "@malloydata/malloy";
+import {
+  FieldDef,
+  FilterExpression,
+  ModelDef,
+  StructDef,
+} from "@malloydata/malloy";
+import { Filter } from "../../types";
 import { ActionMenu } from "../ActionMenu";
+import { AddFilter } from "../AddFilter";
 import { EditFilter } from "../EditFilter";
 
 interface FilterActionMenuProps {
+  model: ModelDef | undefined;
+  modelPath: string;
   source: StructDef;
   filterSource: string;
   removeFilter: () => void;
   editFilter: (filter: FilterExpression) => void;
   closeMenu: () => void;
+  filterField: FieldDef | undefined;
+  parsedFilter: Filter | undefined;
 }
 
 export const FilterActionMenu: React.FC<FilterActionMenuProps> = ({
@@ -28,6 +39,10 @@ export const FilterActionMenu: React.FC<FilterActionMenuProps> = ({
   editFilter,
   closeMenu,
   source,
+  filterField,
+  parsedFilter,
+  model,
+  modelPath,
 }) => {
   return (
     <ActionMenu
@@ -40,14 +55,27 @@ export const FilterActionMenu: React.FC<FilterActionMenuProps> = ({
           iconColor: "filter",
           kind: "sub_menu",
           closeOnComplete: true,
-          Component: ({ onComplete }) => (
-            <EditFilter
-              editFilter={editFilter}
-              onComplete={onComplete}
-              existing={filterSource}
-              source={source}
-            />
-          ),
+          Component: ({ onComplete }) =>
+            filterField && parsedFilter ? (
+              <AddFilter
+                model={model}
+                source={source}
+                field={filterField}
+                addFilter={editFilter}
+                fieldPath={filterField.name}
+                needsRename={false}
+                onComplete={onComplete}
+                modelPath={modelPath}
+                initial={parsedFilter}
+              />
+            ) : (
+              <EditFilter
+                editFilter={editFilter}
+                onComplete={onComplete}
+                existing={filterSource}
+                source={source}
+              />
+            ),
         },
       ]}
     />

--- a/src/app/QuerySummaryPanel/QuerySummaryPanel.tsx
+++ b/src/app/QuerySummaryPanel/QuerySummaryPanel.tsx
@@ -483,8 +483,12 @@ const SummaryItem: React.FC<SummaryItemProps> = ({
           } else if (item.type === "filter") {
             return (
               <FilterActionMenu
+                model={model}
+                modelPath={modelPath}
                 source={source}
                 filterSource={item.filterSource}
+                filterField={item.field}
+                parsedFilter={item.parsed}
                 removeFilter={() =>
                   queryModifiers.removeFilter(stagePath, item.filterIndex)
                 }

--- a/src/core/filters.ts
+++ b/src/core/filters.ts
@@ -14,10 +14,13 @@
 import {
   BooleanFilter,
   BooleanFilterType,
+  Filter,
+  InThePastUnit,
   NumberFilter,
   NumberFilterType,
   StringFilter,
   StringFilterType,
+  ThisLastPeriod,
   TimeFilter,
   TimeFilterType,
 } from "../types";
@@ -293,7 +296,7 @@ export function timeToString(
       const month = digits(time.getUTCMonth() + 1, 2);
       const day = digits(time.getUTCDate(), 2);
       const hour = digits(time.getUTCHours(), 2);
-      return `@${year}-${month}-${day} ${hour}:00 for 1 hour`;
+      return `@${year}-${month}-${day} ${hour}:00`;
     }
     case "minute": {
       const year = digits(time.getUTCFullYear(), 2);
@@ -446,5 +449,594 @@ export function booleanFilterChangeType(
       return { type, partial: "" };
     default:
       return { type };
+  }
+}
+
+type HackyFilterParserResult<T> =
+  | {
+      field: string;
+      filter: T;
+    }
+  | undefined;
+
+const ID_CHAR = "[a-zA-Z_]";
+const DIGIT = "[0-9]";
+const ID = `${ID_CHAR}(?:${ID_CHAR}|${DIGIT})*`;
+const QUOTED_ID = `\`${ID_CHAR}(?:${ID_CHAR}|${DIGIT}|\\s)*\``;
+const FIELD = `(?:${ID}|${QUOTED_ID})`;
+
+const FALSE_FILTER = new RegExp(`^not (${FIELD})$`);
+const TRUE_FILTER = new RegExp(`^(${FIELD})$`);
+const TRUE_OR_NULL_FILTER = new RegExp(`^(${FIELD}):\\s*true\\s*\\|\\s*null$`);
+const FALSE_OR_NULL_FILTER = new RegExp(
+  `^(${FIELD}):\\s*false\\s*\\|\\s*null$`
+);
+const NULL_FILTER = new RegExp(`^(${FIELD})\\s*=\\s*null$`);
+const NOT_NULL_FILTER = new RegExp(`^(${FIELD})\\s*!=\\s*null$`);
+const CUSTOM_FILTER = new RegExp(`^(${FIELD}):\\s*(.*)$`);
+
+function ALTERNATION(kind: "|" | "&", thing: string) {
+  return `${thing}(?:\\s*\\${kind}\\s*${thing}\\s*)*`;
+}
+
+const STRING_ESCAPE = `(?:\\\\\\')|(?:\\\\\\\\)|(?:\\\\.)`;
+const STRING = `\\'(?:${STRING_ESCAPE}|[^\\\\\\\\'])*\\'`;
+const CONTAINS_STRING = `\\'%(?:${STRING_ESCAPE}|[^\\\\\\\\'])*%\\'`;
+const STARTS_STRING = `\\'(?:${STRING_ESCAPE}|[^\\\\\\\\'])*%\\'`;
+const ENDS_STRING = `\\'%(?:${STRING_ESCAPE}|[^\\\\\\\\'])*\\'`;
+const STR_BLANK_FILTER = new RegExp(`^(${FIELD})\\s*=\\s\\'\\'$`);
+const STR_NBLANK_FILTER = new RegExp(`^(${FIELD})\\s*!=\\s\\'\\'$`);
+const STR_EQ_FILTER = new RegExp(
+  `^(${FIELD})\\s*=\\s*(${ALTERNATION("|", STRING)})$`
+);
+const STR_NEQ_FILTER = new RegExp(
+  `^(${FIELD})\\s*!=\\s*(${ALTERNATION("&", STRING)})$`
+);
+const STR_CONTAINS_FILTER = new RegExp(
+  `^(${FIELD})\\s*~\\s*(${ALTERNATION("|", CONTAINS_STRING)})$`
+);
+const STR_NCONTAINS_FILTER = new RegExp(
+  `^(${FIELD})\\s*!~\\s*(${ALTERNATION("&", CONTAINS_STRING)})$`
+);
+const STR_STARTS_FILTER = new RegExp(
+  `^(${FIELD})\\s*~\\s*(${ALTERNATION("|", STARTS_STRING)})$`
+);
+const STR_ENDS_FILTER = new RegExp(
+  `^(${FIELD})\\s*~\\s*(${ALTERNATION("|", ENDS_STRING)})$`
+);
+const STR_NSTARTS_FILTER = new RegExp(
+  `^(${FIELD})\\s*!~\\s*(${ALTERNATION("&", STARTS_STRING)})$`
+);
+const STR_NENDS_FILTER = new RegExp(
+  `^(${FIELD})\\s*!~\\s*(${ALTERNATION("&", ENDS_STRING)})$`
+);
+const NUMBER = `${DIGIT}+(?:\\.${DIGIT}*)?`;
+const NUM_EQ_FILTER = new RegExp(
+  `^(${FIELD})\\s*=\\s*(${ALTERNATION("|", NUMBER)})$`
+);
+const NUM_NEQ_FILTER = new RegExp(
+  `^(${FIELD})\\s*!=\\s*(${ALTERNATION("&", NUMBER)})$`
+);
+const NUM_BET_FILTER = new RegExp(
+  `^(${FIELD})\\s*:\\s*(${NUMBER})\\s*to\\s*(${NUMBER})$`
+);
+const NUM_GT_FILTER = new RegExp(`^(${FIELD})\\s*>\\s*(${NUMBER})$`);
+const NUM_LT_FILTER = new RegExp(`^(${FIELD})\\s*<\\s*(${NUMBER})$`);
+const NUM_LTE_FILTER = new RegExp(`^(${FIELD})\\s*>=\\s*(${NUMBER})$`);
+const NUM_GTE_FILTER = new RegExp(`^(${FIELD})\\s*<=\\s*(${NUMBER})$`);
+
+const TIME_UNIT = `(?:year|quarter|month|week|day|hour|minute|second)`;
+const TIME_PAST_FILTER = new RegExp(
+  `^(${FIELD})\\s*:\\s*now\\s*-\\s*(${NUMBER})\\s*(${TIME_UNIT})s?\\s*for\\s*\\s*(${NUMBER})\\s*(${TIME_UNIT})s?$`
+);
+const TIME_LAST_FILTER = new RegExp(
+  `^(${FIELD})\\.(${TIME_UNIT})\\s*=\\s*now\\.(${TIME_UNIT})\\s*-\\s*1\\s*(${TIME_UNIT})$`
+);
+const TIME_THIS_FILTER = new RegExp(
+  `^(${FIELD})\\.(${TIME_UNIT})\\s*=\\s*now\\.(${TIME_UNIT})$`
+);
+
+const YEAR = `${DIGIT}{4}`;
+const DD = `${DIGIT}{2}`;
+const TIME = `@${YEAR}(?:-${DD}(?:-${DD}(?: ${DD}:${DD}(?::${DD})?)?)?)?`;
+const QUARTER = `@${YEAR}-Q[1234]`;
+const WEEK = `@WK${YEAR}-${DD}-${DD}`;
+
+const DATE = `(?:${TIME}|${QUARTER}|${WEEK})`;
+const TIME_ON_FILTER = new RegExp(
+  `^(${FIELD})\\.(${TIME_UNIT})\\s*=\\s*(${DATE})$`
+);
+const TIME_AFT_FILTER = new RegExp(
+  `^(${FIELD})\\.(${TIME_UNIT})\\s*>\\s*(${DATE})$`
+);
+const TIME_BEF_FILTER = new RegExp(
+  `^(${FIELD})\\.(${TIME_UNIT})\\s*<\\s*(${DATE})$`
+);
+const TIME_BET_FILTER = new RegExp(
+  `^(${FIELD})\\.(${TIME_UNIT})\\s*:\\s*(${DATE})\\s*to\\s*(${DATE})$`
+);
+
+// case "is_after": {
+//   return `${field}.${filter.granularity} > ${timeToString(
+//     filter.date,
+//     filter.granularity
+//   )}`;
+// }
+// case "is_before": {
+//   return `${field}.${filter.granularity} < ${timeToString(
+//     filter.date,
+//     filter.granularity
+//   )}`;
+// }
+// case "is_between": {
+//   return `${field}.${filter.granularity}: ${timeToString(
+//     filter.start,
+//     filter.granularity
+//   )} to ${timeToString(filter.end, filter.granularity)}`;
+// }
+
+// case "is_in_the_past":
+//   return `${field}: now - ${filter.amount} ${filter.unit} for ${filter.amount} ${filter.unit}`;
+// case "is_last":
+//   return `${field}.${filter.period} = now.${filter.period} - 1 ${filter.period}`;
+// case "is_this":
+//   return `${field}.${filter.period} = now.${filter.period}`;
+// case "is_on": {
+//   return `${field}.${filter.granularity} = ${timeToString(
+//     filter.date,
+//     filter.granularity
+//   )}`;
+// }
+
+function extractField(fieldSyntax: string) {
+  if (fieldSyntax.startsWith("`") && fieldSyntax.endsWith("`")) {
+    return fieldSyntax.substring(1, fieldSyntax.length - 1);
+  }
+  return fieldSyntax;
+}
+
+export function hackyTerribleStringToFilter(
+  filterString: string
+): HackyFilterParserResult<Filter> {
+  return (
+    hackyTerribleStringToBooleanFilter(filterString) ??
+    hackyTerribleStringToStringFilter(filterString) ??
+    hackyTerribleStringToNumberFilter(filterString) ??
+    hackyTerribleStringToTimeFilter(filterString) ??
+    hackyTerribleStringToAnyFilter(filterString)
+  );
+}
+
+function hackyTerribleStringToBooleanFilter(
+  filterString: string
+): HackyFilterParserResult<BooleanFilter> {
+  const isFalseMatch = filterString.match(FALSE_FILTER);
+  if (isFalseMatch) {
+    return {
+      field: extractField(isFalseMatch[1]),
+      filter: { type: "is_false" },
+    };
+  }
+  const isTrueMatch = filterString.match(TRUE_FILTER);
+  if (isTrueMatch) {
+    return {
+      field: extractField(isTrueMatch[1]),
+      filter: { type: "is_true" },
+    };
+  }
+  const isTrueOrNullMatch = filterString.match(TRUE_OR_NULL_FILTER);
+  if (isTrueOrNullMatch) {
+    return {
+      field: extractField(isTrueOrNullMatch[1]),
+      filter: { type: "is_true_or_null" },
+    };
+  }
+  const isFalseOrNullMatch = filterString.match(FALSE_OR_NULL_FILTER);
+  if (isFalseOrNullMatch) {
+    return {
+      field: extractField(isFalseOrNullMatch[1]),
+      filter: { type: "is_false_or_null" },
+    };
+  }
+}
+
+function hackyTerribleStringToAnyFilter(
+  filterString
+): HackyFilterParserResult<Filter> {
+  const isNullMatch = filterString.match(NULL_FILTER);
+  if (isNullMatch) {
+    return {
+      field: extractField(isNullMatch[1]),
+      filter: { type: "is_null" },
+    };
+  }
+  const isNotNullMatch = filterString.match(NOT_NULL_FILTER);
+  if (isNotNullMatch) {
+    return {
+      field: extractField(isNotNullMatch[1]),
+      filter: { type: "is_not_null" },
+    };
+  }
+  const isCustomMatch = filterString.match(CUSTOM_FILTER);
+  if (isCustomMatch) {
+    return {
+      field: extractField(isCustomMatch[1]),
+      filter: { type: "custom", partial: isCustomMatch[2] },
+    };
+  }
+}
+
+function deQuote(stringString: string) {
+  return stringString.substring(1, stringString.length - 1);
+}
+
+function deContains(stringString: string) {
+  return stringString.substring(1, stringString.length - 1);
+}
+
+function deStarts(stringString: string) {
+  return stringString.substring(0, stringString.length - 1);
+}
+
+function deEnds(stringString: string) {
+  return stringString.substring(1);
+}
+
+function toNumber(numberString: string) {
+  return parseFloat(numberString);
+}
+
+function getAlternationValues(kind: "|" | "&", alternation: string) {
+  return alternation.split(new RegExp(`\\s*\\${kind}\\s*`));
+}
+
+function toTimeUnit(timeUnitString: string): InThePastUnit {
+  if (
+    [
+      "year",
+      "quarter",
+      "month",
+      "week",
+      "day",
+      "hour",
+      "minute",
+      "second",
+    ].includes(timeUnitString)
+  ) {
+    return (timeUnitString + "s") as InThePastUnit;
+  }
+  throw new Error(`Invalid time unit '${timeUnitString}'`);
+}
+
+function toTimePeriod(timeUnitString: string): ThisLastPeriod {
+  if (
+    [
+      "year",
+      "quarter",
+      "month",
+      "week",
+      "day",
+      "hour",
+      "minute",
+      "second",
+    ].includes(timeUnitString)
+  ) {
+    return timeUnitString as ThisLastPeriod;
+  }
+  throw new Error(`Invalid time period '${timeUnitString}'`);
+}
+
+function toDate(dateString: string): Date {
+  const isDate = dateString.match(new RegExp(`^${TIME}$`));
+  const isWeek = dateString.match(new RegExp(`^${WEEK}$`));
+  if (isDate || isWeek) {
+    const str = isDate ? dateString.substring(1) : dateString.substring(3);
+    if (str.length === 4) {
+      return new Date(parseInt(dateString.substring(0, 4)), 0, 1);
+    } else if (str.length === 7) {
+      return new Date(
+        parseInt(str.substring(0, 4)),
+        parseInt(str.substring(5, 7)) - 1,
+        1
+      );
+    } else if (str.length === 10) {
+      return new Date(
+        parseInt(str.substring(0, 4)),
+        parseInt(str.substring(5, 7)) - 1,
+        parseInt(str.substring(8, 10))
+      );
+    } else if (str.length === 16) {
+      return new Date(
+        parseInt(str.substring(0, 4)),
+        parseInt(str.substring(5, 7)) - 1,
+        parseInt(str.substring(8, 10)),
+        parseInt(str.substring(11, 13)),
+        parseInt(str.substring(14, 16))
+      );
+    } else {
+      return new Date(
+        parseInt(str.substring(0, 4)),
+        parseInt(str.substring(5, 7)) - 1,
+        parseInt(str.substring(8, 10)),
+        parseInt(str.substring(11, 13)),
+        parseInt(str.substring(14, 16)),
+        parseInt(str.substring(17, 19))
+      );
+    }
+  } else if (dateString.match(new RegExp(`^${QUARTER}$`))) {
+    return new Date(
+      parseInt(dateString.substring(1, 5)),
+      3 * parseInt(dateString.substring(7, 8)) - 1,
+      1
+    );
+  }
+  throw new Error(`Invalid Malloy date: ${dateString}`);
+}
+
+function hackyTerribleStringToStringFilter(
+  filterString: string
+): HackyFilterParserResult<StringFilter> {
+  const isBlankMatch = filterString.match(STR_BLANK_FILTER);
+  if (isBlankMatch) {
+    return {
+      field: extractField(isBlankMatch[1]),
+      filter: { type: "is_blank" },
+    };
+  }
+  const isNotBlankMatch = filterString.match(STR_NBLANK_FILTER);
+  if (isNotBlankMatch) {
+    return {
+      field: extractField(isNotBlankMatch[1]),
+      filter: { type: "is_not_blank" },
+    };
+  }
+  const isEqualMatch = filterString.match(STR_EQ_FILTER);
+  if (isEqualMatch) {
+    return {
+      field: extractField(isEqualMatch[1]),
+      filter: {
+        type: "is_equal_to",
+        values: getAlternationValues("|", isEqualMatch[2]).map(deQuote),
+      },
+    };
+  }
+  const isNotEqualMatch = filterString.match(STR_NEQ_FILTER);
+  if (isNotEqualMatch) {
+    return {
+      field: extractField(isNotEqualMatch[1]),
+      filter: {
+        type: "is_not_equal_to",
+        values: getAlternationValues("&", isNotEqualMatch[2]).map(deQuote),
+      },
+    };
+  }
+  const isContainsMatch = filterString.match(STR_CONTAINS_FILTER);
+  if (isContainsMatch) {
+    return {
+      field: extractField(isContainsMatch[1]),
+      filter: {
+        type: "contains",
+        values: getAlternationValues("|", isContainsMatch[2])
+          .map(deQuote)
+          .map(deContains),
+      },
+    };
+  }
+  const isNotContainsMatch = filterString.match(STR_NCONTAINS_FILTER);
+  if (isNotContainsMatch) {
+    return {
+      field: extractField(isNotContainsMatch[1]),
+      filter: {
+        type: "does_not_contain",
+        values: getAlternationValues("&", isNotContainsMatch[2])
+          .map(deQuote)
+          .map(deContains),
+      },
+    };
+  }
+  const isStartsMatch = filterString.match(STR_STARTS_FILTER);
+  if (isStartsMatch) {
+    return {
+      field: extractField(isStartsMatch[1]),
+      filter: {
+        type: "starts_with",
+        values: getAlternationValues("|", isStartsMatch[2])
+          .map(deQuote)
+          .map(deStarts),
+      },
+    };
+  }
+  const isEndsMatch = filterString.match(STR_ENDS_FILTER);
+  if (isEndsMatch) {
+    return {
+      field: extractField(isEndsMatch[1]),
+      filter: {
+        type: "ends_with",
+        values: getAlternationValues("|", isEndsMatch[2])
+          .map(deQuote)
+          .map(deEnds),
+      },
+    };
+  }
+  const isNotStartsMatch = filterString.match(STR_NSTARTS_FILTER);
+  if (isNotStartsMatch) {
+    return {
+      field: extractField(isNotStartsMatch[1]),
+      filter: {
+        type: "does_not_start_with",
+        values: getAlternationValues("&", isNotStartsMatch[2])
+          .map(deQuote)
+          .map(deStarts),
+      },
+    };
+  }
+  const isNotEndsMatch = filterString.match(STR_NENDS_FILTER);
+  if (isNotEndsMatch) {
+    return {
+      field: extractField(isNotEndsMatch[1]),
+      filter: {
+        type: "does_not_end_with",
+        values: getAlternationValues("&", isNotEndsMatch[2])
+          .map(deQuote)
+          .map(deEnds),
+      },
+    };
+  }
+}
+
+function hackyTerribleStringToNumberFilter(
+  filterString: string
+): HackyFilterParserResult<NumberFilter> {
+  const isEqualMatch = filterString.match(NUM_EQ_FILTER);
+  if (isEqualMatch) {
+    return {
+      field: extractField(isEqualMatch[1]),
+      filter: {
+        type: "is_equal_to",
+        values: getAlternationValues("|", isEqualMatch[2]).map(toNumber),
+      },
+    };
+  }
+  const isNotEqualMatch = filterString.match(NUM_NEQ_FILTER);
+  if (isNotEqualMatch) {
+    return {
+      field: extractField(isNotEqualMatch[1]),
+      filter: {
+        type: "is_not_equal_to",
+        values: getAlternationValues("&", isNotEqualMatch[2]).map(toNumber),
+      },
+    };
+  }
+  const isGTMatch = filterString.match(NUM_GT_FILTER);
+  if (isGTMatch) {
+    return {
+      field: extractField(isGTMatch[1]),
+      filter: {
+        type: "is_greater_than",
+        value: toNumber(extractField(isGTMatch[2])),
+      },
+    };
+  }
+  const isLTMatch = filterString.match(NUM_LT_FILTER);
+  if (isLTMatch) {
+    return {
+      field: extractField(isLTMatch[1]),
+      filter: {
+        type: "is_less_than",
+        value: toNumber(extractField(isLTMatch[2])),
+      },
+    };
+  }
+  const isGTEMatch = filterString.match(NUM_GTE_FILTER);
+  if (isGTEMatch) {
+    return {
+      field: extractField(isGTEMatch[1]),
+      filter: {
+        type: "is_greater_than_or_equal_to",
+        value: toNumber(extractField(isGTEMatch[2])),
+      },
+    };
+  }
+  const isLTEMatch = filterString.match(NUM_LTE_FILTER);
+  if (isLTEMatch) {
+    return {
+      field: extractField(isLTEMatch[1]),
+      filter: {
+        type: "is_less_than_or_equal_to",
+        value: toNumber(extractField(isLTEMatch[2])),
+      },
+    };
+  }
+  const isBetweenMatch = filterString.match(NUM_BET_FILTER);
+  if (isBetweenMatch) {
+    return {
+      field: extractField(isBetweenMatch[1]),
+      filter: {
+        type: "is_between",
+        lowerBound: toNumber(extractField(isBetweenMatch[2])),
+        upperBound: toNumber(extractField(isBetweenMatch[3])),
+      },
+    };
+  }
+}
+
+function hackyTerribleStringToTimeFilter(
+  filterString: string
+): HackyFilterParserResult<TimeFilter> {
+  const isPastMatch = filterString.match(TIME_PAST_FILTER);
+  if (isPastMatch) {
+    return {
+      field: extractField(isPastMatch[1]),
+      filter: {
+        type: "is_in_the_past",
+        amount: toNumber(extractField(isPastMatch[2])),
+        unit: toTimeUnit(extractField(isPastMatch[3])),
+      },
+    };
+  }
+  const isLastMatch = filterString.match(TIME_LAST_FILTER);
+  if (isLastMatch) {
+    return {
+      field: extractField(isLastMatch[1]),
+      filter: {
+        type: "is_last",
+        period: toTimePeriod(extractField(isLastMatch[2])),
+      },
+    };
+  }
+  const isThisMatch = filterString.match(TIME_THIS_FILTER);
+  if (isThisMatch) {
+    return {
+      field: extractField(isThisMatch[1]),
+      filter: {
+        type: "is_this",
+        period: toTimePeriod(extractField(isThisMatch[2])),
+      },
+    };
+  }
+  const isOnMatch = filterString.match(TIME_ON_FILTER);
+  if (isOnMatch) {
+    return {
+      field: extractField(isOnMatch[1]),
+      filter: {
+        type: "is_on",
+        granularity: toTimePeriod(extractField(isOnMatch[2])),
+        date: toDate(extractField(isOnMatch[3])),
+      },
+    };
+  }
+  const isAfterMatch = filterString.match(TIME_AFT_FILTER);
+  if (isAfterMatch) {
+    return {
+      field: extractField(isAfterMatch[1]),
+      filter: {
+        type: "is_after",
+        granularity: toTimePeriod(extractField(isAfterMatch[2])),
+        date: toDate(extractField(isAfterMatch[3])),
+      },
+    };
+  }
+  const isBeforeMatch = filterString.match(TIME_BEF_FILTER);
+  if (isBeforeMatch) {
+    return {
+      field: extractField(isBeforeMatch[1]),
+      filter: {
+        type: "is_before",
+        granularity: toTimePeriod(extractField(isBeforeMatch[2])),
+        date: toDate(extractField(isBeforeMatch[3])),
+      },
+    };
+  }
+  const isBetweenMatch = filterString.match(TIME_BET_FILTER);
+  if (isBetweenMatch) {
+    return {
+      field: extractField(isBetweenMatch[1]),
+      filter: {
+        type: "is_between",
+        granularity: toTimePeriod(extractField(isBetweenMatch[2])),
+        start: toDate(extractField(isBetweenMatch[3])),
+        end: toDate(extractField(isBetweenMatch[4])),
+      },
+    };
   }
 }

--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -38,6 +38,7 @@ import {
 } from "@malloydata/malloy";
 import { DataStyles } from "@malloydata/render";
 import { snakeToTitle } from "../app/utils";
+import { hackyTerribleStringToFilter } from "./filters";
 
 class SourceUtils {
   constructor(protected _source: StructDef | undefined) {}
@@ -948,6 +949,7 @@ ${malloy}
   }
 
   private getSummaryItemsForFilterList(
+    source: StructDef,
     filterList: FilterExpression[]
   ): QuerySummaryItemFilter[] {
     const items: QuerySummaryItemFilter[] = [];
@@ -957,7 +959,14 @@ ${malloy}
       filterIndex++
     ) {
       const filter = filterList[filterIndex];
-      items.push({ type: "filter", filterSource: filter.code, filterIndex });
+      const parsed = hackyTerribleStringToFilter(filter.code);
+      items.push({
+        type: "filter",
+        filterSource: filter.code,
+        filterIndex,
+        field: parsed && this.getField(source, parsed.field),
+        parsed: parsed && parsed.filter,
+      });
     }
     return items;
   }
@@ -1087,7 +1096,9 @@ ${malloy}
     const items: QuerySummaryItem[] = [];
     const orderByFields: OrderByField[] = [];
     if (stage.filterList) {
-      items.push(...this.getSummaryItemsForFilterList(stage.filterList));
+      items.push(
+        ...this.getSummaryItemsForFilterList(source, stage.filterList)
+      );
     }
     for (let fieldIndex = 0; fieldIndex < stage.fields.length; fieldIndex++) {
       const field = stage.fields[fieldIndex];
@@ -1143,7 +1154,10 @@ ${malloy}
                 ? this.fanToDef(field, fieldDef)
                 : undefined,
             fieldIndex,
-            filters: this.getSummaryItemsForFilterList(field.filterList || []),
+            filters: this.getSummaryItemsForFilterList(
+              source,
+              field.filterList || []
+            ),
             styles: styleItems.filter((s) => s.canRemove),
             isRefined: true,
             path: field.name,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -182,6 +182,8 @@ export interface QuerySummaryItemFilter {
   type: "filter";
   filterSource: string;
   filterIndex: number;
+  parsed?: Filter;
+  field?: FieldDef;
 }
 
 export interface QuerySummaryItemLimit {


### PR DESCRIPTION
This reconstitutes filters generated by the app into the front-end's understanding of possible filter types, and then uses that to show the filter-editing UI when editing filters.

This is bad, because the front-end is parsing Malloy, which it should never do without the help of the real Malloy parser. 

If you think "wow, that's cool, I want to do this in my app," don't! Just wait until we have a better version of an AST for expressions to work with.

This code will break. It is a mess of regular expressions that are not at all coupled to the language.

Anyway, here's the result:

https://user-images.githubusercontent.com/3538955/202300899-50153583-34c8-486a-adb8-3c36ad5d10ae.mov


https://user-images.githubusercontent.com/3538955/202300912-415d2eef-567b-457e-8896-5f55f10dc8f0.mov

https://user-images.githubusercontent.com/3538955/202300920-97d8d238-d96f-4221-aa34-7d1afd24c38f.mov


https://user-images.githubusercontent.com/3538955/202300928-4490881e-47aa-4161-92d2-6f9eda8a37a8.mov


