### PR TITLE
Auto expand nests

### DIFF
--- a/src/app/Explore/Explore.tsx
+++ b/src/app/Explore/Explore.tsx
@@ -222,6 +222,8 @@ export const Explore: React.FC = () => {
           }
           params.current = urlParams.toString();
         } catch (error) {
+          // eslint-disable-next-line no-console
+          console.error(error);
           setError(error);
         } finally {
           setLoading((loading) => --loading);
@@ -259,6 +261,8 @@ export const Explore: React.FC = () => {
       urlParams.set("page", "query");
       setParams(urlParams, { replace: true });
     } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error);
       setError(error);
     } finally {
       setLoading((loading) => --loading);
@@ -296,6 +300,8 @@ export const Explore: React.FC = () => {
       runQuery();
       setParams(urlParams);
     } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error);
       setError(error);
     } finally {
       setLoading((loading) => --loading);

--- a/src/app/QuerySummaryPanel/QuerySummaryPanel.tsx
+++ b/src/app/QuerySummaryPanel/QuerySummaryPanel.tsx
@@ -330,7 +330,10 @@ const SummaryItem: React.FC<SummaryItemProps> = ({
     <div ref={ref}>
       <ClickToPopover
         popoverContent={({ closeMenu }) => {
-          if (item.type === "field" || item.type === "field_definition") {
+          if (
+            (item.type === "field" || item.type === "field_definition") &&
+            item.kind !== "query"
+          ) {
             if (item.kind === "dimension") {
               return (
                 <DimensionActionMenu
@@ -439,46 +442,6 @@ const SummaryItem: React.FC<SummaryItemProps> = ({
                   }}
                 />
               );
-            } else {
-              return (
-                <SavedQueryActionMenu
-                  source={source}
-                  removeField={() =>
-                    queryModifiers.removeField(stagePath, item.fieldIndex)
-                  }
-                  addFilter={(filter) =>
-                    queryModifiers.addFilterToField(
-                      stagePath,
-                      item.fieldIndex,
-                      filter
-                    )
-                  }
-                  renameField={(newName) => {
-                    queryModifiers.renameField(
-                      stagePath,
-                      item.fieldIndex,
-                      newName
-                    );
-                  }}
-                  addLimit={() => {
-                    /* unused, unimplemented */
-                  }}
-                  replaceWithDefinition={() =>
-                    queryModifiers.replaceWithDefinition(
-                      stagePath,
-                      item.fieldIndex
-                    )
-                  }
-                  closeMenu={closeMenu}
-                  setDataStyle={(renderer) =>
-                    queryModifiers.setDataStyle(item.name, renderer)
-                  }
-                  beginReorderingField={() => {
-                    beginReorderingField(item.fieldIndex);
-                    closeMenu();
-                  }}
-                />
-              );
             }
           } else if (item.type === "filter") {
             return (
@@ -544,7 +507,10 @@ const SummaryItem: React.FC<SummaryItemProps> = ({
                 allowedRenderers={item.allowedRenderers}
               />
             );
-          } else if (item.type === "nested_query_definition") {
+          } else if (
+            item.type === "nested_query_definition" ||
+            (item.type === "field" && item.kind === "query")
+          ) {
             const nestStagePath = stagePathPush(stagePath, {
               fieldIndex: item.fieldIndex,
               stageIndex: 0,

--- a/src/app/hooks/use_query_builder.ts
+++ b/src/app/hooks/use_query_builder.ts
@@ -211,6 +211,8 @@ export function useQueryBuilder(
         setError(undefined);
       } catch (error) {
         queryBuilder.current.setQuery(backup);
+        // eslint-disable-next-line no-console
+        console.error(error);
         setError(error);
       }
     } else {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -143,18 +143,37 @@ export interface Schema {
   fields: SchemaField[];
 }
 
-export interface QuerySummaryItemField {
+export type QuerySummaryItemField =
+  | QuerySummaryItemFieldScalar
+  | QuerySummaryItemFieldQuery;
+
+export interface QuerySummaryItemFieldScalar {
   type: "field";
   field: FieldDef;
   isRefined: boolean;
   isRenamed: boolean;
   saveDefinition: FieldDef | undefined;
   fieldIndex: number;
-  kind: "dimension" | "measure" | "query";
+  kind: "dimension" | "measure";
   name: string;
   path: string;
   filters?: QuerySummaryItemFilter[];
   styles?: QuerySummaryItemDataStyle[];
+}
+
+export interface QuerySummaryItemFieldQuery {
+  type: "field";
+  field: FieldDef;
+  isRefined: boolean;
+  isRenamed: boolean;
+  saveDefinition: FieldDef | undefined;
+  fieldIndex: number;
+  kind: "query";
+  name: string;
+  path: string;
+  filters?: QuerySummaryItemFilter[];
+  styles?: QuerySummaryItemDataStyle[];
+  stages: StageSummary[];
 }
 
 export interface QuerySummaryItemNestedQueryDefinition {


### PR DESCRIPTION
Make the regular (expanded) nested query menu work for unexpanded nested queries, by auto-expanding. 

There seems to be a different bug https://github.com/malloydata/malloy-composer/issues/61 that causes the "Add stage" button to not work on nested queries regardless of whether auto-expanding is necessary.