### PR TITLE
Handle unparsed filters

### DIFF
--- a/src/core/query.ts
+++ b/src/core/query.ts
@@ -762,7 +762,7 @@ export class QueryWriter extends SourceUtils {
     modelPath: string
   ): string {
     const malloy = this.getMalloyString(false, this.query.name);
-    return `<!-- malloy-query  
+    return `<!-- malloy-query
   name="${snakeToTitle(this.query.name)}"
   description="Add a description here." ${
     renderer
@@ -1013,7 +1013,7 @@ ${malloy}
         type: "filter",
         filterSource: filter.code,
         filterIndex,
-        fieldPath: parsed.field,
+        fieldPath: parsed && parsed.field,
         field: parsed && this.getField(source, parsed.field),
         parsed: parsed && parsed.filter,
       });


### PR DESCRIPTION
Fixes https://github.com/malloydata/malloy-composer/issues/64, https://github.com/malloydata/malloy-composer/issues/65 and https://github.com/malloydata/malloy-composer/issues/66. These were all bugs where the filter parsing to bring up the nice filter editor failed, so these will all come up in the regular text box editor now.