### PR TITLE
Allow remote URLS for tables

### DIFF
--- a/src/app/Explore/Explore.tsx
+++ b/src/app/Explore/Explore.tsx
@@ -428,7 +428,7 @@ export const Explore: React.FC = () => {
               <ErrorMessage error={error} />
               {section === "loading" && (
                 <EmptyMessage>
-                  <LoadingSpinner text="Loading..." />
+                  <LoadingSpinner text="Loading Data..." />
                 </EmptyMessage>
               )}
             </PageContainer>

--- a/src/app/data/duckdb_wasm.ts
+++ b/src/app/data/duckdb_wasm.ts
@@ -13,6 +13,7 @@
 
 import { DuckDBWASMConnection } from "@malloydata/db-duckdb/dist/duckdb_wasm_connection";
 import * as malloy from "@malloydata/malloy";
+import e from "express";
 import { HackyDataStylesAccumulator } from "../../common/data_styles";
 import * as explore from "../../types";
 import { snakeToTitle } from "../utils";
@@ -93,11 +94,17 @@ export async function datasets(appRoot: string): Promise<explore.AppInfo> {
     app.models.map(async (sample: explore.ModelConfig) => {
       const connection = await DUCKDB_WASM.lookupConnection("duckdb");
       await Promise.all(
-        sample.tables.map((tableName) => {
-          return connection.database?.registerFileURL(
-            tableName,
-            new URL(tableName, samplesURL).toString()
-          );
+        sample.tables.map((table) => {
+          let tableName: string;
+          let tableUrl: string;
+          if (typeof table === "string") {
+            tableName = table;
+            tableUrl = new URL(tableName, samplesURL).toString();
+          } else {
+            tableName = table.name;
+            tableUrl = table.url;
+          }
+          return connection.database?.registerFileURL(tableName, tableUrl);
         })
       );
       const modelURL = new URL(sample.path, samplesURL);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,10 +45,14 @@ export interface SourceConfig {
   description: string;
 }
 
+export interface RemoteTable {
+  name: string;
+  url: string;
+}
 export interface ModelConfig {
   id: string;
   path: string;
-  tables: string[];
+  tables: Array<string | RemoteTable>;
   sources?: SourceConfig[];
 }
 


### PR DESCRIPTION
For duckdb-wasm only for now, instead of just a table name, you can now enter a table, url structure like:

```json

      "tables": [
        {
          "name": "flights.parquet",
          "url": "https://malloy.github.io/malloy-samples/duckdb/faa/data/flights.parquet"
        },
        {
          "name": "carriers.parquet",
          "url": "https://malloy.github.io/malloy-samples/duckdb/faa/data/carriers.parquet"
        },
        {
          "name": "airports.parquet",
          "url": "https://malloy.github.io/malloy-samples/duckdb/faa/data/airports.parquet"
        }
      ]
```

and reference by name in Malloy
```malloy
source: flights is table('flights.parquet') {}
```