### PR TITLE
Update bundle path/naming.

### DIFF
--- a/scripts/create-release-bundles.ts
+++ b/scripts/create-release-bundles.ts
@@ -33,7 +33,13 @@ async function createReleaseBundle(
     throw new Error(`Could not find: ${targetBinary}`);
 
   const targetName = path.basename(targetBinary);
-  fs.mkdirSync(path.resolve(__dirname, "..", OUT_DIR), { recursive: true });
+  const matches = targetName.match(/^.+-(.+)$/);
+  if (!matches) {
+    throw new Error(`Unknown binary name format: ${targetName}`)
+  }
+  const version = matches[1];
+  const outName = targetName.substring(0, targetName.length - version.length - 1);
+  fs.mkdirSync(path.resolve(__dirname, "..", OUT_DIR, version), { recursive: true });
 
   // Create bundle zip
   const archiveWrapper = new Promise<void>((resolve, reject) => {
@@ -41,7 +47,8 @@ async function createReleaseBundle(
       __dirname,
       "..",
       OUT_DIR,
-      `${targetName}.zip`
+      version,
+      `${outName}.zip`
     );
     const zipFile = fs.createWriteStream(targetZip);
     console.log(`Creating zip bundle:`);

--- a/scripts/create-release-bundles.ts
+++ b/scripts/create-release-bundles.ts
@@ -35,11 +35,16 @@ async function createReleaseBundle(
   const targetName = path.basename(targetBinary);
   const matches = targetName.match(/^.+-(.+)$/);
   if (!matches) {
-    throw new Error(`Unknown binary name format: ${targetName}`)
+    throw new Error(`Unknown binary name format: ${targetName}`);
   }
   const version = matches[1];
-  const outName = targetName.substring(0, targetName.length - version.length - 1);
-  fs.mkdirSync(path.resolve(__dirname, "..", OUT_DIR, version), { recursive: true });
+  const outName = targetName.substring(
+    0,
+    targetName.length - version.length - 1
+  );
+  fs.mkdirSync(path.resolve(__dirname, "..", OUT_DIR, version), {
+    recursive: true,
+  });
 
   // Create bundle zip
   const archiveWrapper = new Promise<void>((resolve, reject) => {

--- a/src/app/Explore/Explore.tsx
+++ b/src/app/Explore/Explore.tsx
@@ -34,8 +34,7 @@ import { useApps } from "../data/use_apps";
 import { Apps } from "../Apps";
 import { LoadingSpinner } from "../Spinner";
 
-const MALLOY_DOCS =
-  "https://malloydata.github.io/malloy/documentation/";
+const MALLOY_DOCS = "https://malloydata.github.io/malloy/documentation/";
 
 const KEY_MAP = {
   REMOVE_FIELDS: "command+k",


### PR DESCRIPTION
Update the way bundles are named to allow usage of the 'latest' version when creating links to github versions.

Example:
https://github.com/malloydata/malloy-composer/releases/latest/download/malloy-composer-cli-macos-x64.zip