### PR TITLE
Add back "Duplicate" for nested saved queries

### DIFF
--- a/src/app/Explore/Explore.tsx
+++ b/src/app/Explore/Explore.tsx
@@ -34,8 +34,7 @@ import { useApps } from "../data/use_apps";
 import { Apps } from "../Apps";
 import { LoadingSpinner } from "../Spinner";
 
-const MALLOY_DOCS =
-  "https://malloydata.github.io/malloy/documentation/";
+const MALLOY_DOCS = "https://malloydata.github.io/malloy/documentation/";
 
 const KEY_MAP = {
   REMOVE_FIELDS: "command+k",

--- a/src/app/NestQueryActionMenu/NestQueryActionMenu.tsx
+++ b/src/app/NestQueryActionMenu/NestQueryActionMenu.tsx
@@ -70,6 +70,8 @@ interface NestQueryActionMenuProps {
   rename: (newName: string) => void;
   model: ModelDef | undefined;
   modelPath: string | undefined;
+  isExpanded: boolean;
+  replaceWithDefinition: () => void;
 }
 
 export const NestQueryActionMenu: React.FC<NestQueryActionMenuProps> = ({
@@ -91,6 +93,8 @@ export const NestQueryActionMenu: React.FC<NestQueryActionMenuProps> = ({
   addStage,
   topValues,
   rename,
+  isExpanded,
+  replaceWithDefinition,
 }) => {
   return (
     <ActionMenu
@@ -247,6 +251,15 @@ export const NestQueryActionMenu: React.FC<NestQueryActionMenuProps> = ({
           iconName: "stage",
           iconColor: "other",
           onClick: addStage,
+        },
+        {
+          kind: "one_click",
+          id: "expand_definition",
+          label: "Duplicate",
+          iconName: "duplicate",
+          iconColor: "other",
+          isEnabled: !isExpanded,
+          onClick: replaceWithDefinition,
         },
         {
           kind: "one_click",

--- a/src/app/QuerySummaryPanel/QuerySummaryPanel.tsx
+++ b/src/app/QuerySummaryPanel/QuerySummaryPanel.tsx
@@ -24,7 +24,6 @@ import { ActionIcon } from "../ActionIcon";
 import { Popover } from "../Popover";
 import { DimensionActionMenu } from "../DimensionActionMenu";
 import { AggregateActionMenu } from "../AggregateActionMenu";
-import { SavedQueryActionMenu } from "../SavedQueryActionMenu";
 import { LimitActionMenu } from "../LimitActionMenu";
 import { ListNest } from "../ListNest";
 import { NestQueryActionMenu } from "../NestQueryActionMenu";
@@ -553,6 +552,13 @@ const SummaryItem: React.FC<SummaryItemProps> = ({
                   beginReorderingField(item.fieldIndex);
                   closeMenu();
                 }}
+                isExpanded={item.type === "nested_query_definition"}
+                replaceWithDefinition={() =>
+                  queryModifiers.replaceWithDefinition(
+                    stagePath,
+                    item.fieldIndex
+                  )
+                }
               />
             );
           } else if (item.type === "error_field") {


### PR DESCRIPTION
https://github.com/malloydata/malloy-composer/pull/60 accidentally removed the ability to expand a query without modifying it. This PR adds it back.

![Screen Shot 2022-11-28 at 1 22 41 PM](https://user-images.githubusercontent.com/3538955/204363506-ec854c12-5f75-4154-a027-165a6ae8e3ee.png)
