### PR TITLE
Catch more errors when linting

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -24,11 +24,7 @@ module.exports = {
     "plugin:@typescript-eslint/eslint-recommended",
     "plugin:@typescript-eslint/recommended",
   ],
-  ignorePatterns: [
-    "*.d.ts",
-    "node_modules/",
-    "packages/malloy/src/lang/lib/Malloy",
-  ],
+  ignorePatterns: ["*.d.ts", "node_modules", "build", "dist"],
   parser: "@typescript-eslint/parser",
   parserOptions: {
     warnOnUnsupportedTypeScriptVersion: false,

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 build
 composer_config.json
 dist

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Malloy",
   "license": "GPL-2.0",
   "scripts": {
-    "lint": "eslint src scripts",
+    "lint": "tsc && eslint .",
     "start": "npm run server-build && node ./dist/cli.js",
     "build": "ts-node scripts/build",
     "clean": "rm -rf ./build && rm -rf ./dist && rm -rf ./pkg",

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -137,7 +137,7 @@ export function fieldToSummaryItem(
       isRenamed: false,
       fieldIndex: -1,
       kind,
-    };
+    } as QuerySummaryItem;
   }
 }
 

--- a/src/core/compile.ts
+++ b/src/core/compile.ts
@@ -13,8 +13,6 @@
 
 import {
   Connection,
-  FetchSchemaAndRunSimultaneously,
-  FetchSchemaAndRunStreamSimultaneously,
   FieldDef,
   FilterExpression,
   FixedConnectionMap,
@@ -55,6 +53,13 @@ class DummyConnection implements Connection {
     throw new Error("Dummy connection cannot run SQL blocks.");
   }
 
+  fetchSchemaForSQLBlock(): Promise<
+    | { structDef: StructDef; error?: undefined }
+    | { error: string; structDef?: undefined }
+  > {
+    throw new Error("Dummy connection cannot fetch schemas.");
+  }
+
   fetchSchemaForSQLBlocks(): Promise<{
     schemas: Record<string, StructDef>;
     errors: Record<string, string>;
@@ -77,7 +82,7 @@ class DummyConnection implements Connection {
     return false;
   }
 
-  canFetchSchemaAndRunSimultaneously(): this is FetchSchemaAndRunSimultaneously {
+  canFetchSchemaAndRunSimultaneously() {
     return false;
   }
 
@@ -85,7 +90,7 @@ class DummyConnection implements Connection {
     return false;
   }
 
-  canFetchSchemaAndRunStreamSimultaneously(): this is FetchSchemaAndRunStreamSimultaneously {
+  canFetchSchemaAndRunStreamSimultaneously() {
     return false;
   }
 }

--- a/src/core/compile.ts
+++ b/src/core/compile.ts
@@ -82,15 +82,7 @@ class DummyConnection implements Connection {
     return false;
   }
 
-  canFetchSchemaAndRunSimultaneously() {
-    return false;
-  }
-
   canStream(): this is StreamingConnection {
-    return false;
-  }
-
-  canFetchSchemaAndRunStreamSimultaneously() {
     return false;
   }
 }


### PR DESCRIPTION
esbuild doesn't report a lot of typescript build errors, so compile as part of linting.