### PR TITLE
Don't rely on checked in binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ out
 pkg
 public/js
 bundle/
+third_party/github.com/duckdb/
+third_party/github.com/atom/
 
 # misc
 .DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "malloy-third-party"]
-	path = malloy-third-party
-	url = https://github.com/malloydata/malloy-third-party
 [submodule "malloy-samples"]
 	path = malloy-samples
 	url = https://github.com/malloydata/malloy-samples.git

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -20,6 +20,7 @@ import fs from "fs";
 import { copyDirSync } from "./utils";
 
 import duckdbPackage from "@malloydata/db-duckdb/package.json";
+import { fetchDuckDB } from "./utils/fetch_duckdb";
 const DUCKDB_VERSION = duckdbPackage.dependencies.duckdb;
 
 export const targetDuckDBMap: Record<string, string> = {
@@ -159,17 +160,8 @@ export async function doBuild(target?: string): Promise<void> {
     if (duckDBBinaryName === undefined) {
       throw new Error(`No DuckDB binary for ${target} is available`);
     }
-    fs.copyFileSync(
-      path.join(
-        "malloy-third-party",
-        "third_party",
-        "github.com",
-        "duckdb",
-        "duckdb",
-        duckDBBinaryName
-      ),
-      path.join(buildDirectory, "duckdb-native.node")
-    );
+    const fileName = await fetchDuckDB(target);
+    fs.copyFileSync(fileName, path.join(buildDirectory, "duckdb-native.node"));
   }
 }
 

--- a/scripts/package-server.ts
+++ b/scripts/package-server.ts
@@ -17,17 +17,9 @@ import * as pkg from "pkg";
 import * as fs from "fs";
 import * as path from "path";
 import { Command } from "commander";
+import { targetDuckDBMap } from "./utils/fetch_duckdb";
 
-import duckdbPackage from "@malloydata/db-duckdb/package.json";
-const DUCKDB_VERSION = duckdbPackage.dependencies.duckdb;
-const duckdbPath = "../malloy-third-party/third_party/github.com/duckdb/duckdb";
-
-const duckDbTargetMap = new Map<string, string>([
-  ["darwin-arm64", `duckdb-v${DUCKDB_VERSION}-node-v93-darwin-arm64.node`],
-  ["darwin-x64", `duckdb-v${DUCKDB_VERSION}-node-v93-darwin-x64.node`],
-  ["linux-x64", `duckdb-v${DUCKDB_VERSION}-node-v93-linux-x64.node`],
-  ["win32-x64", `duckdb-v${DUCKDB_VERSION}-node-v93-win32-x64.node`],
-]);
+const duckdbPath = "../third_party/github.com/duckdb/duckdb";
 
 const nodeTarget = "node16";
 
@@ -46,12 +38,12 @@ async function packageServer(
     console.log(`Signing not yet implemented`);
   }
 
-  if (!duckDbTargetMap.has(target)) {
+  if (!targetDuckDBMap[target]) {
     throw new Error(`No DuckDb defined for target: ${target}`);
   }
 
   fs.copyFileSync(
-    path.resolve(__dirname, `${duckdbPath}/${duckDbTargetMap.get(target)}`),
+    path.resolve(__dirname, `${duckdbPath}/${targetDuckDBMap[target]}`),
     path.resolve(__dirname, "../dist/duckdb-native.node"),
     fs.constants.COPYFILE_FICLONE
   );

--- a/scripts/utils/fetch_duckdb.ts
+++ b/scripts/utils/fetch_duckdb.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+
+/* eslint-disable no-console */
+import * as fs from "fs";
+import * as path from "path";
+
+import duckdbPackage from "@malloydata/db-duckdb/package.json";
+import { fetchNode } from "./fetch_node";
+
+const DUCKDB_VERSION = duckdbPackage.dependencies.duckdb;
+
+export const targetDuckDBMap: Record<string, string> = {
+  "darwin-arm64": `duckdb-v${DUCKDB_VERSION}-node-v93-darwin-arm64.node`,
+  "darwin-x64": `duckdb-v${DUCKDB_VERSION}-node-v93-darwin-x64.node`,
+  "linux-x64": `duckdb-v${DUCKDB_VERSION}-node-v93-linux-x64.node`,
+  "win32-x64": `duckdb-v${DUCKDB_VERSION}-node-v93-win32-x64.node`,
+};
+
+export const fetchDuckDB = async (target: string): Promise<string> => {
+  const file = targetDuckDBMap[target];
+  const url = `https://duckdb-node.s3.amazonaws.com/duckdb-v${DUCKDB_VERSION}-node-v93-${target}.tar.gz`;
+  const directoryPath = path.resolve(
+    path.join("third_party", "github.com", "duckdb", "duckdb")
+  );
+  fs.mkdirSync(directoryPath, { recursive: true });
+  const filePath = path.join(directoryPath, file);
+
+  await fetchNode(filePath, url);
+
+  return filePath;
+};

--- a/scripts/utils/fetch_node.ts
+++ b/scripts/utils/fetch_node.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+
+import * as fs from "fs";
+import * as zlib from "zlib";
+import fetch from "node-fetch";
+import tar from "tar-stream";
+
+/* eslint-disable no-console */
+export const fetchNode = async (
+  filePath: string,
+  url: string
+): Promise<void> => {
+  console.info(`Fetching: ${url}`);
+  const extract = tar.extract();
+  const response = await fetch(url);
+  await new Promise((resolve, reject) => {
+    if (fs.existsSync(filePath)) {
+      console.info(`Already exists: ${filePath}`);
+      return;
+    }
+
+    try {
+      extract.on("entry", async (header, stream, _next) => {
+        const outFile = fs.openSync(filePath, "w", header.mode);
+        stream.on("end", () => {
+          fs.closeSync(outFile);
+          resolve(null);
+        });
+
+        for await (const chunk of stream) {
+          fs.writeFileSync(outFile, chunk);
+        }
+      });
+
+      extract.on("finish", function () {
+        resolve(null);
+      });
+      extract.on("error", function (error) {
+        console.error(error);
+        reject(error);
+      });
+    } catch (error) {
+      console.error(error);
+      reject(error);
+    }
+    if (response.ok) {
+      const stream = response.body;
+      if (stream) {
+        console.info(`Reading: ${url}`);
+        stream.pipe(zlib.createGunzip()).pipe(extract);
+      }
+    } else {
+      console.error(`Failed to fetch ${url}: ${response.statusText}`);
+    }
+  });
+  console.log("done");
+};

--- a/third_party/github.com/evanw/esbuild/native-modules-plugin.ts
+++ b/third_party/github.com/evanw/esbuild/native-modules-plugin.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+
+// https://github.com/evanw/esbuild/issues/1051#issuecomment-806325487
+export const nativeNodeModulesPlugin = {
+  name: "native-node-modules",
+  setup(build: any): void {
+    // If a ".node" file is imported within a module in the "file" namespace, resolve
+    // it to an absolute path and put it into the "node-file" virtual namespace.
+    build.onResolve({ filter: /\.node$/, namespace: "file" }, (args: any) => ({
+      path: require.resolve(args.path, { paths: [args.resolveDir] }),
+      namespace: "node-file",
+    }));
+
+    // Files in the "node-file" virtual namespace call "require()" on the
+    // path from esbuild of the ".node" file in the output directory.
+    build.onLoad({ filter: /.*/, namespace: "node-file" }, (args: any) => ({
+      contents: `
+        import path from ${JSON.stringify(args.path)}
+        try { module.exports = require(path) }
+        catch {}
+      `,
+    }));
+
+    // If a ".node" file is imported within a module in the "node-file" namespace, put
+    // it in the "file" namespace where esbuild's default loading behavior will handle
+    // it. It is already an absolute path since we resolved it to one above.
+    build.onResolve(
+      { filter: /\.node$/, namespace: "node-file" },
+      (args: any) => ({
+        path: args.path,
+        namespace: "file",
+      })
+    );
+
+    // Tell esbuild's default loading behavior to use the "file" loader for
+    // these ".node" files.
+    const opts = build.initialOptions;
+    opts.loader = opts.loader || {};
+    opts.loader[".node"] = "file";
+  },
+};

--- a/third_party/github.com/evanw/esbuild/no-node-modules-sourcemaps.ts
+++ b/third_party/github.com/evanw/esbuild/no-node-modules-sourcemaps.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+
+import fs from "fs";
+
+// https://github.com/evanw/esbuild/issues/1685#issuecomment-944916409
+export const noNodeModulesSourceMaps = {
+  name: "excludeVendorFromSourceMap",
+  setup(build: any): void {
+    build.onLoad({ filter: /node_modules/ }, (args: any) => {
+      if (args.path.endsWith(".js")) {
+        return {
+          contents:
+            fs.readFileSync(args.path, "utf8") +
+            "\n//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIiJdLCJtYXBwaW5ncyI6IkEifQ==",
+          loader: "default",
+        };
+      }
+    });
+  },
+};


### PR DESCRIPTION
Per a security bot's request, we will no longer rely on checked in binaries to package, instead fetching them on demand.