### PR TITLE
Updated update scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "build-duckdb-wasm": "ts-node scripts/build-duckdb-wasm",
     "start-duckdb-wasm": "NODE_ENV=development npm run build-duckdb-wasm 9999",
     "watch-duckdb-wasm": "NODE_ENV=development npm run build-duckdb-wasm",
-    "malloy-install": "npm --no-fund --no-audit install --save-exact $npm_package_config_malloy_packages",
-    "malloy-update": "npm --no-fund --no-audit unlink $npm_package_config_malloy_packages && npm run malloy-install",
+    "malloy-update-next": "npm install  --no-fund --no-audit --save-exact $(echo $malloy_packages | sed -E 's/(@malloydata\\/[-a-z]+)/\\1@next/g')",
+    "malloy-update": "npm install  --no-fund --no-audit --save-exact $(echo $malloy_packages | sed -E 's/(@malloydata\\/[-a-z]+)/\\1@latest/g')",
     "malloy-link": "npm --no-fund --no-audit link $npm_package_config_malloy_packages",
     "malloy-unlink": "npm --no-fund --no-save --no-audit unlink $npm_package_config_malloy_packages && npm --no-fund --no-audit install --force"
   },


### PR DESCRIPTION
Don't unlink, explicitly apply `@current` and `@next` to ensure only Malloy packages are affected.