### PR TITLE
Preserve query when updating model

### DIFF
--- a/packages/query-composer/example/example.tsx
+++ b/packages/query-composer/example/example.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, {useState} from 'react';
 import ReactDOM from 'react-dom';
 import {ExploreQueryEditor, useQueryBuilder, useRunQuery} from '../src/index';
 
-import {model, modelPath, source, topValues} from './example_model';
+import {model as exampleModel, modelPath, topValues} from './example_model';
 import styled, {createGlobalStyle} from 'styled-components';
+import {SourceDef} from '@malloydata/malloy';
 
 const updateQueryInURL = () => {};
 const runQueryAction = () => {
@@ -39,14 +40,17 @@ const CssVariables = styled.div`
 `;
 
 const App = () => {
+  const [modelDef, setModeDef] = useState(exampleModel);
   const {queryMalloy, queryName, queryModifiers, querySummary} =
-    useQueryBuilder(model, 'names', modelPath, updateQueryInURL);
+    useQueryBuilder(modelDef, 'names', modelPath, updateQueryInURL);
 
   const {result, isRunning, runQuery} = useRunQuery(
-    model,
+    modelDef,
     modelPath,
     runQueryAction
   );
+
+  const source = modelDef.contents['names'] as SourceDef;
 
   return (
     <div className="dark">
@@ -59,7 +63,7 @@ const App = () => {
           }}
         >
           <ExploreQueryEditor
-            model={model}
+            model={modelDef}
             modelPath={modelPath}
             source={source}
             queryModifiers={queryModifiers}
@@ -70,6 +74,7 @@ const App = () => {
             runQuery={runQuery}
             isRunning={isRunning}
             result={result}
+            refreshModel={() => setModeDef(structuredClone(exampleModel))}
           />
         </div>
       </CssVariables>

--- a/packages/query-composer/src/hooks/index.ts
+++ b/packages/query-composer/src/hooks/index.ts
@@ -22,4 +22,5 @@
  */
 
 export {useClickOutside} from './use_click_outside';
-export {useQueryBuilder, QueryModifiers} from './use_query_builder';
+export {useQueryBuilder} from './use_query_builder';
+export type {QueryModifiers} from './use_query_builder';


### PR DESCRIPTION
Add simulated model refresh to example, fix query being discarded when model is refreshed.