### PR TITLE
Result refactor

### DIFF
--- a/packages/query-composer/example/example.tsx
+++ b/packages/query-composer/example/example.tsx
@@ -41,8 +41,12 @@ const CssVariables = styled.div`
 
 const App = () => {
   const [modelDef, setModeDef] = useState(exampleModel);
-  const {queryMalloy, queryName, queryModifiers, querySummary} =
-    useQueryBuilder(modelDef, 'names', modelPath, updateQueryInURL);
+  const {queryModifiers, querySummary, queryWriter} = useQueryBuilder(
+    modelDef,
+    'names',
+    modelPath,
+    updateQueryInURL
+  );
 
   const {result, isRunning, runQuery} = useRunQuery(
     modelDef,
@@ -67,9 +71,8 @@ const App = () => {
             source={source}
             queryModifiers={queryModifiers}
             topValues={topValues}
-            queryName={queryName}
             querySummary={querySummary}
-            queryMalloy={queryMalloy}
+            queryWriter={queryWriter}
             runQuery={runQuery}
             isRunning={isRunning}
             result={result}

--- a/packages/query-composer/example/example2.tsx
+++ b/packages/query-composer/example/example2.tsx
@@ -1,0 +1,113 @@
+import React, {useState} from 'react';
+import {createRoot} from 'react-dom/client';
+import {useQueryBuilder, useRunQuery} from '../src/index';
+
+import {model as exampleModel, modelPath, topValues} from './example_model';
+import styled, {createGlobalStyle} from 'styled-components';
+import {SourceDef} from '@malloydata/malloy';
+import {QueryEditor} from '../src/components/QueryEditor';
+
+const updateQueryInURL = () => {};
+const runQueryAction = () => {
+  throw new Error('Unimplemented');
+};
+
+const CssVariables = styled.div`
+  --malloy-composer-fontSize: 13px;
+  --malloy-composer-fontFamily: Arial, sans-serif;
+  --malloy-composer-background: #1e1e1e;
+  --malloy-composer-foreground: #eeeeee;
+
+  --malloy-composer-header-background: #333333;
+
+  --malloy-composer-code-fontSize: 13px;
+  --malloy-composer-code-fontFamily: Courier, monospace;
+
+  --malloy-composer-form-background: #000000;
+  --malloy-composer-form-foreground: #eeeeee;
+  --malloy-composer-form-border: #ececed;
+  --malloy-composer-form-fontFamily: Arial, sans-serif;
+  --malloy-composer-form-fontSize: 13px;
+  --malloy-composer-form-focus: #b0b0ff;
+  --malloy-composer-form-focusBackground: #5050ff;
+  --malloy-composer-form-fontSize: 13px;
+
+  --malloy-composer-menu-background: #000000;
+  --malloy-composer-menu-foreground: #eeeeee;
+  --malloy-composer-menu-border: #bbbbbb;
+  --malloy-composer-menu-title: #bbbbbb;
+  --malloy-composer-menu-fontFamily: Courier, monospace;
+  --malloy-composer-menu-fontSize: 13px;
+`;
+
+const App = () => {
+  const [modelDef, setModeDef] = useState(exampleModel);
+  const {queryModifiers, querySummary, queryWriter} = useQueryBuilder(
+    modelDef,
+    'names',
+    modelPath,
+    updateQueryInURL
+  );
+
+  const {isRunning, runQuery} = useRunQuery(
+    modelDef,
+    modelPath,
+    runQueryAction
+  );
+
+  const source = modelDef.contents['names'] as SourceDef;
+
+  const runQueryCallback = () => {
+    const query = queryWriter.getQueryStringForNotebook();
+    if (query) {
+      runQuery(query);
+    }
+  };
+
+  return (
+    <div className="dark">
+      <GlobalStyle />
+      <CssVariables>
+        <div
+          style={{
+            backgroundColor: 'var(--malloy-composer-background)',
+          }}
+        >
+          <QueryEditor
+            model={modelDef}
+            source={source}
+            queryModifiers={queryModifiers}
+            topValues={topValues}
+            querySummary={querySummary}
+            queryWriter={queryWriter}
+            runQuery={runQueryCallback}
+            isRunning={isRunning}
+            refreshModel={() => setModeDef(structuredClone(exampleModel))}
+          />
+        </div>
+      </CssVariables>
+    </div>
+  );
+};
+
+const GlobalStyle = createGlobalStyle`
+  .dark .shiki,
+  .dark .shiki span {
+    color: var(--shiki-dark) !important;
+    background-color: var(--shiki-dark-bg) !important;
+  }
+  .shiki span {
+    font-size: var(--malloy-composer-code-fontSize);
+    font-family: var(--malloy-composer-code-fontFamily);
+  }
+  .shiki code {
+    background-color: var(--malloy-composer-background);
+  }
+
+  body {
+    margin: 0;
+  }
+`;
+
+const root = createRoot(document.getElementById('app')!);
+root.render(<App />);

--- a/packages/query-composer/example/index.ts
+++ b/packages/query-composer/example/index.ts
@@ -1,2 +1,2 @@
-import './example.tsx';
+import './example2.tsx';
 export * from './example_model.ts';

--- a/packages/query-composer/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/query-composer/src/components/ActionMenu/ActionMenu.tsx
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 import * as React from 'react';
-import {FilterCondition, StructDef, ModelDef} from '@malloydata/malloy';
+import {FilterCondition, StructDef} from '@malloydata/malloy';
 import {ReactElement, useContext, useState} from 'react';
 import styled from 'styled-components';
 import {stringFilterToString} from '../../core/filters';
@@ -72,13 +72,9 @@ interface ActionMenuProps {
   closeMenu: () => void;
   searchItems?: SearchItem[];
   addFilter?: (filter: FilterCondition) => void;
-  model?: ModelDef;
-  modelPath?: string;
 }
 
 export const ActionMenu: React.FC<ActionMenuProps> = ({
-  model,
-  modelPath,
   actions,
   closeMenu,
   searchItems,
@@ -91,12 +87,7 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
       : undefined
   );
   const [searchTerm, setSearchTerm] = useState('');
-  const {searchResults, isLoading} = useSearch(
-    model,
-    modelPath,
-    valueSearchSource,
-    searchTerm
-  );
+  const {searchResults, isLoading} = useSearch(searchTerm);
   const stringSearchResults =
     searchResults &&
     searchResults.filter(r => r.fieldType === 'string').slice(0, 100);

--- a/packages/query-composer/src/components/AddFilter/AddFilter.tsx
+++ b/packages/query-composer/src/components/AddFilter/AddFilter.tsx
@@ -21,12 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 import * as React from 'react';
-import {
-  FieldDef,
-  FilterCondition,
-  ModelDef,
-  StructDef,
-} from '@malloydata/malloy';
+import {FieldDef, FilterCondition, StructDef} from '@malloydata/malloy';
 import {useContext, useState} from 'react';
 import {CodeInput} from '../CodeInput';
 import {
@@ -62,20 +57,16 @@ import {kindOfField, typeOfField} from '../../utils';
 import {ComposerOptionsContext} from '../ExploreQueryEditor/ExploreQueryEditor';
 
 interface AddFilterProps {
-  model: ModelDef;
   source: StructDef;
   field: FieldDef;
   fieldPath: string;
   addFilter: (filter: FilterCondition, as?: string) => void;
   needsRename: boolean;
   onComplete: () => void;
-  modelPath: string;
   initial?: Filter;
 }
 
 export const AddFilter: React.FC<AddFilterProps> = ({
-  model,
-  modelPath,
   source,
   field,
   addFilter,
@@ -168,9 +159,6 @@ export const AddFilter: React.FC<AddFilterProps> = ({
         )}
         {stringFilter && (
           <StringFilterBuilder
-            modelPath={modelPath}
-            model={model}
-            source={source}
             fieldPath={fieldPath}
             filter={stringFilter}
             setFilter={f => {

--- a/packages/query-composer/src/components/AddFilter/StringFilterBuilder.tsx
+++ b/packages/query-composer/src/components/AddFilter/StringFilterBuilder.tsx
@@ -21,7 +21,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 import * as React from 'react';
-import {ModelDef, StructDef} from '@malloydata/malloy';
 import {useState} from 'react';
 import styled from 'styled-components';
 import {stringFilterChangeType} from '../../core/filters';
@@ -49,18 +48,12 @@ import {LoadingSpinner} from '../Spinner';
 import {largeNumberLabel} from '../../utils';
 
 interface StringFilterBuilderProps {
-  model: ModelDef;
-  modelPath: string;
-  source: StructDef;
   fieldPath: string;
   filter: StringFilter;
   setFilter: (filter: StringFilter) => void;
 }
 
 export const StringFilterBuilder: React.FC<StringFilterBuilderProps> = ({
-  model,
-  modelPath,
-  source,
   filter,
   setFilter,
   fieldPath,
@@ -69,14 +62,7 @@ export const StringFilterBuilder: React.FC<StringFilterBuilderProps> = ({
     setFilter(stringFilterChangeType(filter, type));
   };
 
-  const equalTo = useStringEqualToOrNotBuilder(
-    model,
-    modelPath,
-    source,
-    filter,
-    setFilter,
-    fieldPath
-  );
+  const equalTo = useStringEqualToOrNotBuilder(filter, setFilter, fieldPath);
   const startsWith = useStringContainsBuilder(filter, setFilter);
   const doesNotStartWith = useStringNotContainsBuilder(filter, setFilter);
   const contains = useStringStartsWithBuilder(filter, setFilter);
@@ -159,21 +145,12 @@ const UtilRow = styled.div`
 `;
 
 function useStringEqualToOrNotBuilder(
-  model: ModelDef,
-  modelPath: string,
-  source: StructDef,
   filter: StringFilter,
   setFilter: (filter: StringEqualToFilter | StringNotEqualToFilter) => void,
   fieldPath: string
 ) {
   const [searchValue, setSearchValue] = useState('');
-  const {searchResults, isLoading} = useSearch(
-    model,
-    modelPath,
-    source,
-    searchValue,
-    fieldPath
-  );
+  const {searchResults, isLoading} = useSearch(searchValue, fieldPath);
   if (filter.type !== 'is_equal_to' && filter.type !== 'is_not_equal_to') {
     return {builder: null, util: null};
   }

--- a/packages/query-composer/src/components/AggregateActionMenu/AggregateActionMenu.tsx
+++ b/packages/query-composer/src/components/AggregateActionMenu/AggregateActionMenu.tsx
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 import * as React from 'react';
-import {ModelDef, SourceDef} from '@malloydata/malloy';
+import {SourceDef} from '@malloydata/malloy';
 import {OrderByField, PropertyType, StagePath} from '../../types';
 import {FilterContextBar} from '../FilterContextBar';
 import {RenameField} from '../RenameField';
@@ -42,15 +42,11 @@ interface AggregateActionMenuProps {
   definition: string | undefined;
   orderByField: OrderByField;
   stagePath: StagePath;
-  model: ModelDef;
-  modelPath: string;
   queryModifiers: QueryModifiers;
   property: PropertyType;
 }
 
 export const AggregateActionMenu: React.FC<AggregateActionMenuProps> = ({
-  model,
-  modelPath,
   source,
   closeMenu,
   beginReorderingField,
@@ -79,8 +75,6 @@ export const AggregateActionMenu: React.FC<AggregateActionMenuProps> = ({
           closeOnComplete: true,
           Component: ({onComplete}: ActionSubmenuComponentProps) => (
             <FilterContextBar
-              model={model}
-              modelPath={modelPath}
               source={source}
               addFilter={(filter, as) =>
                 queryModifiers.addFilterToField(

--- a/packages/query-composer/src/components/DimensionActionMenu/DimensionActionMenu.tsx
+++ b/packages/query-composer/src/components/DimensionActionMenu/DimensionActionMenu.tsx
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 import * as React from 'react';
-import {FieldDef, StructDef, ModelDef} from '@malloydata/malloy';
+import {FieldDef, StructDef} from '@malloydata/malloy';
 import {OrderByField, StagePath, StageSummary} from '../../types';
 import {ActionMenu, ActionSubmenuComponentProps} from '../ActionMenu';
 import {AddFilter} from '../AddFilter';
@@ -32,7 +32,6 @@ import {RenameField} from '../RenameField';
 import {QueryModifiers} from '../../hooks';
 
 interface DimensionActionMenuProps {
-  model: ModelDef;
   closeMenu: () => void;
   stagePath: StagePath;
   fieldIndex: number;
@@ -45,14 +44,11 @@ interface DimensionActionMenuProps {
   filterField?: FieldDef;
   filterFieldPath?: string;
   orderByField: OrderByField;
-  modelPath: string;
   queryModifiers: QueryModifiers;
 }
 
 export const DimensionActionMenu: React.FC<DimensionActionMenuProps> = ({
   source,
-  model,
-  modelPath,
   name,
   closeMenu,
   fieldIndex,
@@ -95,8 +91,6 @@ export const DimensionActionMenu: React.FC<DimensionActionMenuProps> = ({
           Component: ({onComplete}: ActionSubmenuComponentProps) =>
             filterField && filterFieldPath ? (
               <AddFilter
-                model={model}
-                modelPath={modelPath}
                 onComplete={onComplete}
                 source={source}
                 field={filterField}

--- a/packages/query-composer/src/components/ExploreQueryEditor/ExploreQueryEditor.tsx
+++ b/packages/query-composer/src/components/ExploreQueryEditor/ExploreQueryEditor.tsx
@@ -52,20 +52,20 @@ export const ExploreQueryEditor: React.FC<ExploreQueryEditorProps> = ({
 }) => {
   const [result, setResult] = useState<MalloyResult>();
   const [error, setError] = useState<Error>();
-  const [_lastRunQuery, setLastRunQuery] = useState<string>();
 
-  const query = queryWriter.getQueryStringForNotebook();
   const {isRunnable} = querySummary ?? {isRunnable: false};
 
-  const runQueryCallback = React.useCallback(() => {
-    if (!isRunnable || !query) {
-      return;
-    }
-    setResult(undefined);
-    setError(undefined);
-    setLastRunQuery(query);
-    runQuery(query);
-  }, [isRunnable, query, runQuery]);
+  const runQueryCallback = React.useCallback(
+    (query: string) => {
+      if (!isRunnable) {
+        return;
+      }
+      setResult(undefined);
+      setError(undefined);
+      runQuery(query);
+    },
+    [isRunnable, runQuery]
+  );
 
   useEffect(() => {
     if (currentResult instanceof Error) {
@@ -86,6 +86,7 @@ export const ExploreQueryEditor: React.FC<ExploreQueryEditorProps> = ({
             modelPath={modelPath}
             queryModifiers={queryModifiers}
             querySummary={querySummary}
+            queryWriter={queryWriter}
             source={source}
             refreshModel={refreshModel}
             runQuery={runQueryCallback}

--- a/packages/query-composer/src/components/ExploreQueryEditor/ExploreQueryEditor.tsx
+++ b/packages/query-composer/src/components/ExploreQueryEditor/ExploreQueryEditor.tsx
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import * as React from 'react';
 import {
   SearchValueMapResult,

--- a/packages/query-composer/src/components/ExploreQueryEditor/ExploreQueryEditor.tsx
+++ b/packages/query-composer/src/components/ExploreQueryEditor/ExploreQueryEditor.tsx
@@ -83,7 +83,6 @@ export const ExploreQueryEditor: React.FC<ExploreQueryEditorProps> = ({
           <QueryEditor
             isRunning={isRunning}
             model={model}
-            modelPath={modelPath}
             queryModifiers={queryModifiers}
             querySummary={querySummary}
             queryWriter={queryWriter}

--- a/packages/query-composer/src/components/ExploreQueryEditor/ExploreQueryEditor.tsx
+++ b/packages/query-composer/src/components/ExploreQueryEditor/ExploreQueryEditor.tsx
@@ -21,7 +21,7 @@ interface ExploreQueryEditorProps {
   queryWriter: QueryWriter;
   querySummary: QuerySummary | undefined;
   queryModifiers: QueryModifiers;
-  runQuery: (query: string) => void;
+  runQuery: (query: string, queryName?: string) => void;
   refreshModel?: () => void;
   isRunning: boolean;
   result: MalloyResult | Error | undefined;
@@ -56,13 +56,13 @@ export const ExploreQueryEditor: React.FC<ExploreQueryEditorProps> = ({
   const {isRunnable} = querySummary ?? {isRunnable: false};
 
   const runQueryCallback = React.useCallback(
-    (query: string) => {
+    (query: string, queryName?: string) => {
       if (!isRunnable) {
         return;
       }
       setResult(undefined);
       setError(undefined);
-      runQuery(query);
+      runQuery(query, queryName);
     },
     [isRunnable, runQuery]
   );

--- a/packages/query-composer/src/components/ExploreQueryEditor/ExploreQueryEditor.tsx
+++ b/packages/query-composer/src/components/ExploreQueryEditor/ExploreQueryEditor.tsx
@@ -4,23 +4,16 @@ import {
   SourceDef,
   Result as MalloyResult,
   ModelDef,
-  TurtleDef,
 } from '@malloydata/malloy';
 import {createContext, useEffect, useState} from 'react';
 import styled from 'styled-components';
 import {QuerySummary} from '../../types';
-import {ActionIcon} from '../ActionIcon';
-import {PageContent, PageHeader} from '../CommonElements';
 import {QueryModifiers} from '../../hooks';
-import {Popover} from '../Popover';
-import {QuerySummaryPanel} from '../QuerySummaryPanel';
 import {Result} from '../Result';
-import {TopQueryActionMenu} from '../TopQueryActionMenu';
-import RunIcon from '../../assets/img/query_run_wide.svg?react';
-import {LoadTopQueryContextBar} from '../LoadTopQueryContextBar';
 import {DummyCompile} from '../../core/dummy-compile';
 import {SearchContext} from '../../contexts/search_context';
 import {ErrorMessage} from '../ErrorMessage';
+import {QueryEditor} from '../QueryEditor';
 
 interface ExploreQueryEditorProps {
   source: SourceDef;
@@ -32,7 +25,6 @@ interface ExploreQueryEditorProps {
     source: string;
     markdown: string;
     notebook: string;
-    isRunnable: boolean;
   };
   queryModifiers: QueryModifiers;
   runQuery: (query: string, queryName: string) => void;
@@ -51,8 +43,6 @@ export const ComposerOptionsContext = createContext<{
   dummyCompiler: DummyCompile;
 }>(composerOptions);
 
-const useLoad = true;
-
 export const ExploreQueryEditor: React.FC<ExploreQueryEditorProps> = ({
   model,
   modelPath,
@@ -67,13 +57,12 @@ export const ExploreQueryEditor: React.FC<ExploreQueryEditorProps> = ({
   queryMalloy,
   queryModifiers,
 }) => {
-  const [insertOpen, setInsertOpen] = useState(false);
-  const [loadOpen, setLoadOpen] = useState(false);
   const [result, setResult] = useState<MalloyResult>();
   const [error, setError] = useState<Error>();
-  const [lastRunQuery, setLastRunQuery] = useState<string>();
+  const [_lastRunQuery, setLastRunQuery] = useState<string>();
 
-  const {notebook: query, isRunnable} = queryMalloy;
+  const {notebook: query} = queryMalloy;
+  const {isRunnable} = querySummary ?? {isRunnable: false};
 
   const runQueryCallback = React.useCallback(() => {
     if (!isRunnable) {
@@ -94,123 +83,22 @@ export const ExploreQueryEditor: React.FC<ExploreQueryEditorProps> = ({
     }
   }, [currentResult]);
 
-  const isQueryEmpty = !querySummary || querySummary.stages.length === 0;
-
-  const clearQuery = () => {
-    queryModifiers.clearQuery();
-    setResult(undefined);
-    setError(undefined);
-  };
-
-  const replaceQuery = (field: TurtleDef) => {
-    queryModifiers.replaceQuery(field);
-    setResult(undefined);
-    setError(undefined);
-  };
-
-  const loadQuery = (name: string) => {
-    queryModifiers.loadQuery(name);
-    setResult(undefined);
-    setError(undefined);
-  };
-
-  const dirty = query !== lastRunQuery;
-
   return (
     <ComposerOptionsContext.Provider value={composerOptions}>
       <SearchContext.Provider value={{topValues}}>
         <Outer>
           <SidebarOuter>
-            <SidebarHeader>
-              {source && (
-                <>
-                  <div>
-                    {refreshModel && (
-                      <ActionIcon
-                        action="refresh"
-                        onClick={() => refreshModel()}
-                        color="dimension"
-                      />
-                    )}
-                  </div>
-                  <div>
-                    <ActionIcon
-                      action="add"
-                      onClick={() => setInsertOpen(true)}
-                      color="dimension"
-                    />
-                    <Popover open={insertOpen} setOpen={setInsertOpen}>
-                      <TopQueryActionMenu
-                        model={model}
-                        modelPath={modelPath}
-                        source={source}
-                        queryModifiers={queryModifiers}
-                        stagePath={{stageIndex: 0}}
-                        orderByFields={
-                          querySummary?.stages[0].orderByFields || []
-                        }
-                        closeMenu={() => setInsertOpen(false)}
-                        queryName={queryName}
-                        stageSummary={querySummary?.stages[0]}
-                        isOnlyStage={querySummary?.stages.length === 1}
-                      />
-                    </Popover>
-                  </div>
-                  <div>
-                    <ActionIcon
-                      action="load"
-                      onClick={() => setLoadOpen(true)}
-                      color="query"
-                    />
-                    <Popover open={loadOpen} setOpen={setLoadOpen}>
-                      <LoadTopQueryContextBar
-                        model={model}
-                        source={source}
-                        selectField={field =>
-                          useLoad
-                            ? loadQuery(field.as || field.name)
-                            : replaceQuery(field as TurtleDef)
-                        }
-                        onComplete={() => setLoadOpen(false)}
-                      />
-                    </Popover>
-                  </div>
-                  <ActionIcon
-                    action="remove"
-                    onClick={clearQuery}
-                    color={isQueryEmpty ? 'other' : 'dimension'}
-                    title="Clear Query"
-                  />
-                  <StyledRunIcon
-                    width="80px"
-                    onClick={runQueryCallback}
-                    className={
-                      isRunning
-                        ? 'running'
-                        : isQueryEmpty || !isRunnable
-                        ? 'blank'
-                        : dirty
-                        ? 'dirty'
-                        : 'clean'
-                    }
-                  />
-                </>
-              )}
-            </SidebarHeader>
-            <QueryBar>
-              <QueryBarInner>
-                {querySummary && (
-                  <QuerySummaryPanel
-                    model={model}
-                    modelPath={modelPath}
-                    source={source}
-                    querySummary={querySummary}
-                    queryModifiers={queryModifiers}
-                    stagePath={undefined}
-                  />
-                )}
-              </QueryBarInner>
-            </QueryBar>
+            <QueryEditor
+              isRunning={isRunning}
+              model={model}
+              modelPath={modelPath}
+              queryModifiers={queryModifiers}
+              queryName={queryName}
+              querySummary={querySummary}
+              source={source}
+              refreshModel={refreshModel}
+              runQuery={runQueryCallback}
+            />
           </SidebarOuter>
           <ResultOuter>
             <Result
@@ -218,6 +106,7 @@ export const ExploreQueryEditor: React.FC<ExploreQueryEditorProps> = ({
               source={source}
               result={result}
               malloy={queryMalloy}
+              querySummary={querySummary}
               onDrill={queryModifiers.onDrill}
               isRunning={isRunning}
             />
@@ -257,47 +146,4 @@ const ResultOuter = styled.div`
   flex-direction: column;
   overflow: hidden;
   gap: 10px;
-`;
-
-const QueryBar = styled(PageContent)`
-  display: flex;
-  overflow-y: auto;
-  flex-direction: column;
-`;
-
-const QueryBarInner = styled.div`
-  padding: 10px;
-`;
-
-const SidebarHeader = styled(PageHeader)`
-  gap: 20px;
-  justify-content: center;
-  align-items: center;
-`;
-
-const StyledRunIcon = styled(RunIcon)`
-  cursor: pointer;
-  &.running,
-  &.blank {
-    .backgroundfill {
-      fill: #e9e9e9;
-    }
-    .foregroundstroke {
-      stroke: #a7a7a7;
-    }
-    .foregroundfill {
-      fill: #a7a7a7;
-    }
-  }
-  &.clean {
-    .backgroundfill {
-      fill: #ffffff;
-    }
-    .foregroundstroke {
-      stroke: #4285f4;
-    }
-    .foregroundfill {
-      fill: #4285f4;
-    }
-  }
 `;

--- a/packages/query-composer/src/components/ExploreQueryEditor/ExploreQueryEditor.tsx
+++ b/packages/query-composer/src/components/ExploreQueryEditor/ExploreQueryEditor.tsx
@@ -11,7 +11,6 @@ import {QuerySummary} from '../../types';
 import {QueryModifiers} from '../../hooks';
 import {Result} from '../Result';
 import {DummyCompile} from '../../core/dummy-compile';
-import {SearchContext} from '../../contexts/search_context';
 import {ErrorMessage} from '../ErrorMessage';
 import {QueryEditor} from '../QueryEditor';
 
@@ -85,35 +84,34 @@ export const ExploreQueryEditor: React.FC<ExploreQueryEditorProps> = ({
 
   return (
     <ComposerOptionsContext.Provider value={composerOptions}>
-      <SearchContext.Provider value={{topValues}}>
-        <Outer>
-          <SidebarOuter>
-            <QueryEditor
-              isRunning={isRunning}
-              model={model}
-              modelPath={modelPath}
-              queryModifiers={queryModifiers}
-              queryName={queryName}
-              querySummary={querySummary}
-              source={source}
-              refreshModel={refreshModel}
-              runQuery={runQueryCallback}
-            />
-          </SidebarOuter>
-          <ResultOuter>
-            <Result
-              model={model}
-              source={source}
-              result={result}
-              malloy={queryMalloy}
-              querySummary={querySummary}
-              onDrill={queryModifiers.onDrill}
-              isRunning={isRunning}
-            />
-            <ErrorMessage error={error} />
-          </ResultOuter>
-        </Outer>
-      </SearchContext.Provider>
+      <Outer>
+        <SidebarOuter>
+          <QueryEditor
+            isRunning={isRunning}
+            model={model}
+            modelPath={modelPath}
+            queryModifiers={queryModifiers}
+            queryName={queryName}
+            querySummary={querySummary}
+            source={source}
+            refreshModel={refreshModel}
+            runQuery={runQueryCallback}
+            topValues={topValues}
+          />
+        </SidebarOuter>
+        <ResultOuter>
+          <Result
+            model={model}
+            source={source}
+            result={result}
+            malloy={queryMalloy}
+            querySummary={querySummary}
+            onDrill={queryModifiers.onDrill}
+            isRunning={isRunning}
+          />
+          <ErrorMessage error={error} />
+        </ResultOuter>
+      </Outer>
     </ComposerOptionsContext.Provider>
   );
 };

--- a/packages/query-composer/src/components/ExploreQueryEditor/index.ts
+++ b/packages/query-composer/src/components/ExploreQueryEditor/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export {ExploreQueryEditor} from './ExploreQueryEditor';

--- a/packages/query-composer/src/components/FilterActionMenu/FilterActionMenu.tsx
+++ b/packages/query-composer/src/components/FilterActionMenu/FilterActionMenu.tsx
@@ -21,12 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 import * as React from 'react';
-import {
-  FieldDef,
-  FilterCondition,
-  ModelDef,
-  StructDef,
-} from '@malloydata/malloy';
+import {FieldDef, FilterCondition, StructDef} from '@malloydata/malloy';
 import {Filter, StagePath} from '../../types';
 import {ActionMenu, ActionSubmenuComponentProps} from '../ActionMenu';
 import {AddFilter} from '../AddFilter';
@@ -34,8 +29,6 @@ import {EditFilter} from '../EditFilter';
 import {QueryModifiers} from '../../hooks';
 
 interface FilterActionMenuProps {
-  model: ModelDef;
-  modelPath: string;
   stagePath: StagePath;
   source: StructDef;
   filterSource: string;
@@ -54,8 +47,6 @@ export const FilterActionMenu: React.FC<FilterActionMenuProps> = ({
   source,
   filterField,
   parsedFilter,
-  model,
-  modelPath,
   stagePath,
   fieldPath,
   fieldIndex,
@@ -78,14 +69,12 @@ export const FilterActionMenu: React.FC<FilterActionMenuProps> = ({
           Component: ({onComplete}: ActionSubmenuComponentProps) =>
             filterField && parsedFilter ? (
               <AddFilter
-                model={model}
                 source={source}
                 field={filterField}
                 addFilter={editFilter}
                 fieldPath={fieldPath}
                 needsRename={false}
                 onComplete={onComplete}
-                modelPath={modelPath}
                 initial={parsedFilter}
               />
             ) : (

--- a/packages/query-composer/src/components/FilterContextBar/FilterContextBar.tsx
+++ b/packages/query-composer/src/components/FilterContextBar/FilterContextBar.tsx
@@ -21,12 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 import * as React from 'react';
-import {
-  FieldDef,
-  FilterCondition,
-  ModelDef,
-  StructDef,
-} from '@malloydata/malloy';
+import {FieldDef, FilterCondition, StructDef} from '@malloydata/malloy';
 import {useContext, useState} from 'react';
 import {AddFilter} from '../AddFilter';
 import {
@@ -56,13 +51,9 @@ interface FilterContextBarProps {
   addFilter: (filter: FilterCondition, as?: string) => void;
   onComplete: () => void;
   needsRename: boolean;
-  model: ModelDef;
-  modelPath: string;
 }
 
 export const FilterContextBar: React.FC<FilterContextBarProps> = ({
-  model,
-  modelPath,
   source,
   addFilter,
   onComplete,
@@ -71,12 +62,7 @@ export const FilterContextBar: React.FC<FilterContextBarProps> = ({
   const {dummyCompiler} = useContext(ComposerOptionsContext);
   const [searchTerm, setSearchTerm] = useState('');
   const [field, setField] = useState<{path: string; def: FieldDef}>();
-  const {searchResults, isLoading} = useSearch(
-    model,
-    modelPath,
-    source,
-    searchTerm
-  );
+  const {searchResults, isLoading} = useSearch(searchTerm);
   const stringSearchResults =
     searchResults &&
     searchResults.filter(r => r.fieldType === 'string').slice(0, 100);
@@ -115,8 +101,6 @@ export const FilterContextBar: React.FC<FilterContextBarProps> = ({
       <div>
         {field && (
           <AddFilter
-            model={model}
-            modelPath={modelPath}
             source={source}
             fieldPath={field.path}
             field={field.def}

--- a/packages/query-composer/src/components/NestQueryActionMenu/NestQueryActionMenu.tsx
+++ b/packages/query-composer/src/components/NestQueryActionMenu/NestQueryActionMenu.tsx
@@ -29,7 +29,7 @@ import {FilterContextBar} from '../FilterContextBar';
 import {AddLimit} from '../AddLimit';
 import {OrderByContextBar} from '../OrderByContextBar';
 import {ActionMenu, ActionSubmenuComponentProps} from '../ActionMenu';
-import {SourceDef, ModelDef} from '@malloydata/malloy';
+import {SourceDef} from '@malloydata/malloy';
 import {DataStyleContextBar} from '../DataStyleContextBar';
 import {
   fieldToSummaryItem,
@@ -47,15 +47,11 @@ interface NestQueryActionMenuProps {
   orderByFields: OrderByField[];
   closeMenu: () => void;
   beginReorderingField: () => void;
-  model: ModelDef;
-  modelPath: string;
   isExpanded: boolean;
   queryModifiers: QueryModifiers;
 }
 
 export const NestQueryActionMenu: React.FC<NestQueryActionMenuProps> = ({
-  model,
-  modelPath,
   source,
   stagePath,
   fieldIndex,
@@ -67,8 +63,6 @@ export const NestQueryActionMenu: React.FC<NestQueryActionMenuProps> = ({
 }) => {
   return (
     <ActionMenu
-      model={model}
-      modelPath={modelPath}
       valueSearchSource={source}
       addFilter={filter => queryModifiers.addFilter(stagePath, filter)}
       closeMenu={closeMenu}
@@ -82,8 +76,6 @@ export const NestQueryActionMenu: React.FC<NestQueryActionMenuProps> = ({
           closeOnComplete: true,
           Component: ({onComplete}: ActionSubmenuComponentProps) => (
             <FilterContextBar
-              modelPath={modelPath}
-              model={model}
               source={source}
               addFilter={(filter, as) =>
                 queryModifiers.addFilter(stagePath, filter, as)

--- a/packages/query-composer/src/components/QueryEditor/QueryEditor.tsx
+++ b/packages/query-composer/src/components/QueryEditor/QueryEditor.tsx
@@ -24,7 +24,6 @@ const useLoad = true;
 export interface QueryEditorProps {
   isRunning: boolean;
   model: ModelDef;
-  modelPath: string;
   refreshModel?: () => void;
   queryModifiers: QueryModifiers;
   querySummary: QuerySummary | undefined;
@@ -37,7 +36,6 @@ export interface QueryEditorProps {
 export const QueryEditor = ({
   isRunning,
   model,
-  modelPath,
   queryModifiers,
   querySummary,
   queryWriter,
@@ -97,8 +95,6 @@ export const QueryEditor = ({
                 />
                 <Popover open={insertOpen} setOpen={setInsertOpen}>
                   <TopQueryActionMenu
-                    model={model}
-                    modelPath={modelPath}
                     source={source}
                     queryModifiers={queryModifiers}
                     stagePath={{stageIndex: 0}}
@@ -154,9 +150,6 @@ export const QueryEditor = ({
           <QueryBarInner>
             {querySummary && (
               <QuerySummaryPanel
-                model={model}
-                modelPath={modelPath}
-                source={source}
                 querySummary={querySummary}
                 queryModifiers={queryModifiers}
                 stagePath={undefined}

--- a/packages/query-composer/src/components/QueryEditor/QueryEditor.tsx
+++ b/packages/query-composer/src/components/QueryEditor/QueryEditor.tsx
@@ -17,6 +17,7 @@ import {QueryModifiers} from '../../hooks';
 import {QuerySummary} from '../../types';
 import styled from 'styled-components';
 import {SearchContext} from '../../contexts/search_context';
+import {QueryWriter} from '../../core/query';
 
 const useLoad = true;
 
@@ -27,7 +28,8 @@ export interface QueryEditorProps {
   refreshModel?: () => void;
   queryModifiers: QueryModifiers;
   querySummary: QuerySummary | undefined;
-  runQuery: () => void;
+  queryWriter: QueryWriter;
+  runQuery: (query: string) => void;
   source: SourceDef;
   topValues: SearchValueMapResult[] | undefined;
 }
@@ -38,6 +40,7 @@ export const QueryEditor = ({
   modelPath,
   queryModifiers,
   querySummary,
+  queryWriter,
   refreshModel,
   runQuery,
   source,
@@ -45,9 +48,12 @@ export const QueryEditor = ({
 }: QueryEditorProps) => {
   const [insertOpen, setInsertOpen] = useState(false);
   const [loadOpen, setLoadOpen] = useState(false);
+  const [lastRunQuery, setLastRunQuery] = useState<string>('');
 
   const isQueryEmpty = !querySummary || querySummary.stages.length === 0;
   const {isRunnable} = querySummary ?? {isRunnable: false};
+
+  const query = queryWriter.getQueryStringForNotebook();
 
   const clearQuery = () => {
     queryModifiers.clearQuery();
@@ -61,7 +67,12 @@ export const QueryEditor = ({
     queryModifiers.loadQuery(name);
   };
 
-  const dirty = false; // query !== lastRunQuery;
+  const dirty = query !== lastRunQuery;
+
+  const onRun = () => {
+    setLastRunQuery(query);
+    runQuery(query);
+  };
 
   return (
     <SearchContext.Provider value={{topValues}}>
@@ -125,7 +136,7 @@ export const QueryEditor = ({
               />
               <StyledRunIcon
                 width="80px"
-                onClick={runQuery}
+                onClick={onRun}
                 className={
                   isRunning
                     ? 'running'

--- a/packages/query-composer/src/components/QueryEditor/QueryEditor.tsx
+++ b/packages/query-composer/src/components/QueryEditor/QueryEditor.tsx
@@ -26,7 +26,6 @@ export interface QueryEditorProps {
   modelPath: string;
   refreshModel?: () => void;
   queryModifiers: QueryModifiers;
-  queryName: string;
   querySummary: QuerySummary | undefined;
   runQuery: () => void;
   source: SourceDef;
@@ -38,7 +37,6 @@ export const QueryEditor = ({
   model,
   modelPath,
   queryModifiers,
-  queryName,
   querySummary,
   refreshModel,
   runQuery,
@@ -95,7 +93,6 @@ export const QueryEditor = ({
                     stagePath={{stageIndex: 0}}
                     orderByFields={querySummary?.stages[0].orderByFields || []}
                     closeMenu={() => setInsertOpen(false)}
-                    queryName={queryName}
                     stageSummary={querySummary?.stages[0]}
                     isOnlyStage={querySummary?.stages.length === 1}
                   />

--- a/packages/query-composer/src/components/QueryEditor/QueryEditor.tsx
+++ b/packages/query-composer/src/components/QueryEditor/QueryEditor.tsx
@@ -28,7 +28,7 @@ export interface QueryEditorProps {
   queryModifiers: QueryModifiers;
   querySummary: QuerySummary | undefined;
   queryWriter: QueryWriter;
-  runQuery: (query: string) => void;
+  runQuery: (query: string, queryName?: string) => void;
   source: SourceDef;
   topValues: SearchValueMapResult[] | undefined;
 }
@@ -69,7 +69,7 @@ export const QueryEditor = ({
 
   const onRun = () => {
     setLastRunQuery(query);
-    runQuery(query);
+    runQuery(query, querySummary?.name);
   };
 
   return (

--- a/packages/query-composer/src/components/QueryEditor/QueryEditor.tsx
+++ b/packages/query-composer/src/components/QueryEditor/QueryEditor.tsx
@@ -1,0 +1,204 @@
+import * as React from 'react';
+import {useState} from 'react';
+import {QuerySummaryPanel} from '../QuerySummaryPanel';
+import {ModelDef, SourceDef, TurtleDef} from '@malloydata/malloy';
+import {ActionIcon} from '../ActionIcon';
+import {PageContent, PageHeader} from '../CommonElements';
+import {LoadTopQueryContextBar} from '../LoadTopQueryContextBar';
+import {Popover} from '../Popover';
+import {TopQueryActionMenu} from '../TopQueryActionMenu';
+import RunIcon from '../../assets/img/query_run_wide.svg?react';
+import {QueryModifiers} from '../../hooks';
+import {QuerySummary} from '../../types';
+import styled from 'styled-components';
+
+const useLoad = true;
+
+export interface QueryEditorProps {
+  isRunning: boolean;
+  model: ModelDef;
+  modelPath: string;
+  refreshModel?: () => void;
+  queryModifiers: QueryModifiers;
+  queryName: string;
+  querySummary: QuerySummary | undefined;
+  runQuery: () => void;
+  source: SourceDef;
+}
+
+export const QueryEditor = ({
+  isRunning,
+  model,
+  modelPath,
+  queryModifiers,
+  queryName,
+  querySummary,
+  refreshModel,
+  runQuery,
+  source,
+}: QueryEditorProps) => {
+  const [insertOpen, setInsertOpen] = useState(false);
+  const [loadOpen, setLoadOpen] = useState(false);
+
+  const isQueryEmpty = !querySummary || querySummary.stages.length === 0;
+  const {isRunnable} = querySummary ?? {isRunnable: false};
+
+  const clearQuery = () => {
+    queryModifiers.clearQuery();
+  };
+
+  const replaceQuery = (field: TurtleDef) => {
+    queryModifiers.replaceQuery(field);
+  };
+
+  const loadQuery = (name: string) => {
+    queryModifiers.loadQuery(name);
+  };
+
+  const dirty = false; // query !== lastRunQuery;
+
+  return (
+    <SidebarOuter>
+      <SidebarHeader>
+        {source && (
+          <>
+            <div>
+              {refreshModel && (
+                <ActionIcon
+                  action="refresh"
+                  onClick={() => refreshModel()}
+                  color="dimension"
+                />
+              )}
+            </div>
+            <div>
+              <ActionIcon
+                action="add"
+                onClick={() => setInsertOpen(true)}
+                color="dimension"
+              />
+              <Popover open={insertOpen} setOpen={setInsertOpen}>
+                <TopQueryActionMenu
+                  model={model}
+                  modelPath={modelPath}
+                  source={source}
+                  queryModifiers={queryModifiers}
+                  stagePath={{stageIndex: 0}}
+                  orderByFields={querySummary?.stages[0].orderByFields || []}
+                  closeMenu={() => setInsertOpen(false)}
+                  queryName={queryName}
+                  stageSummary={querySummary?.stages[0]}
+                  isOnlyStage={querySummary?.stages.length === 1}
+                />
+              </Popover>
+            </div>
+            <div>
+              <ActionIcon
+                action="load"
+                onClick={() => setLoadOpen(true)}
+                color="query"
+              />
+              <Popover open={loadOpen} setOpen={setLoadOpen}>
+                <LoadTopQueryContextBar
+                  model={model}
+                  source={source}
+                  selectField={field =>
+                    useLoad
+                      ? loadQuery(field.as || field.name)
+                      : replaceQuery(field as TurtleDef)
+                  }
+                  onComplete={() => setLoadOpen(false)}
+                />
+              </Popover>
+            </div>
+            <ActionIcon
+              action="remove"
+              onClick={clearQuery}
+              color={isQueryEmpty ? 'other' : 'dimension'}
+              title="Clear Query"
+            />
+            <StyledRunIcon
+              width="80px"
+              onClick={runQuery}
+              className={
+                isRunning
+                  ? 'running'
+                  : isQueryEmpty || !isRunnable
+                  ? 'blank'
+                  : dirty
+                  ? 'dirty'
+                  : 'clean'
+              }
+            />
+          </>
+        )}
+      </SidebarHeader>
+      <QueryBar>
+        <QueryBarInner>
+          {querySummary && (
+            <QuerySummaryPanel
+              model={model}
+              modelPath={modelPath}
+              source={source}
+              querySummary={querySummary}
+              queryModifiers={queryModifiers}
+              stagePath={undefined}
+            />
+          )}
+        </QueryBarInner>
+      </QueryBar>
+    </SidebarOuter>
+  );
+};
+
+const QueryBar = styled(PageContent)`
+  display: flex;
+  overflow-y: auto;
+  flex-direction: column;
+`;
+
+const QueryBarInner = styled.div`
+  padding: 10px;
+`;
+
+const SidebarOuter = styled.div`
+  width: 300px;
+  min-width: 300px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  z-index: 1000;
+`;
+
+const SidebarHeader = styled(PageHeader)`
+  gap: 20px;
+  justify-content: center;
+  align-items: center;
+`;
+
+const StyledRunIcon = styled(RunIcon)`
+  cursor: pointer;
+  &.running,
+  &.blank {
+    .backgroundfill {
+      fill: #e9e9e9;
+    }
+    .foregroundstroke {
+      stroke: #a7a7a7;
+    }
+    .foregroundfill {
+      fill: #a7a7a7;
+    }
+  }
+  &.clean {
+    .backgroundfill {
+      fill: #ffffff;
+    }
+    .foregroundstroke {
+      stroke: #4285f4;
+    }
+    .foregroundfill {
+      fill: #4285f4;
+    }
+  }
+`;

--- a/packages/query-composer/src/components/QueryEditor/index.ts
+++ b/packages/query-composer/src/components/QueryEditor/index.ts
@@ -1,0 +1,2 @@
+export {QueryEditor} from './QueryEditor';
+export type {QueryEditorProps} from './QueryEditor';

--- a/packages/query-composer/src/components/QuerySummaryPanel/QuerySummaryPanel.tsx
+++ b/packages/query-composer/src/components/QuerySummaryPanel/QuerySummaryPanel.tsx
@@ -23,7 +23,6 @@
 import * as React from 'react';
 
 import {QuerySummary, StagePath, stagePathPush} from '../../types';
-import {ModelDef, SourceDef} from '@malloydata/malloy';
 import {EmptyMessage} from '../CommonElements';
 import {StageActionMenu} from '../StageActionMenu';
 import {BackPart, CloseIconStyled} from '../FieldButton/FieldButton';
@@ -34,17 +33,12 @@ import {ClickToPopover} from './ClickToPopover';
 import {StageButton} from './StageButton';
 
 export interface QuerySummaryPanelProps {
-  model: ModelDef;
-  source: SourceDef;
   querySummary: QuerySummary;
   stagePath: StagePath | undefined;
   queryModifiers: QueryModifiers;
-  modelPath: string;
 }
 
 export const QuerySummaryPanel: React.FC<QuerySummaryPanelProps> = ({
-  model,
-  modelPath,
   querySummary,
   stagePath,
   queryModifiers,
@@ -76,8 +70,6 @@ export const QuerySummaryPanel: React.FC<QuerySummaryPanelProps> = ({
               <ClickToPopover
                 popoverContent={({closeMenu}) => (
                   <StageActionMenu
-                    model={model}
-                    modelPath={modelPath}
                     source={stageSummary.inputSource}
                     stagePath={nestStagePath}
                     orderByFields={stageSummary.orderByFields}
@@ -106,8 +98,6 @@ export const QuerySummaryPanel: React.FC<QuerySummaryPanelProps> = ({
               />
             )}
             <StageSummaryUI
-              model={model}
-              modelPath={modelPath}
               stageSummary={stageSummary}
               queryModifiers={queryModifiers}
               stagePath={nestStagePath}

--- a/packages/query-composer/src/components/QuerySummaryPanel/StateSummaryUI.tsx
+++ b/packages/query-composer/src/components/QuerySummaryPanel/StateSummaryUI.tsx
@@ -7,7 +7,7 @@
 
 import * as React from 'react';
 import {useEffect, useState} from 'react';
-import {ModelDef, SourceDef} from '@malloydata/malloy';
+import {SourceDef} from '@malloydata/malloy';
 import {StagePath, StageSummary} from '../../types';
 import {QueryModifiers} from '../../hooks';
 import {notUndefined} from '../../utils';
@@ -20,13 +20,9 @@ interface SummaryStageProps {
   source: SourceDef;
   fieldIndex?: number | undefined;
   queryModifiers: QueryModifiers;
-  model: ModelDef;
-  modelPath: string;
 }
 
 export const StageSummaryUI: React.FC<SummaryStageProps> = ({
-  model,
-  modelPath,
   stageSummary,
   queryModifiers,
   source,
@@ -72,8 +68,6 @@ export const StageSummaryUI: React.FC<SummaryStageProps> = ({
     <FieldListDiv>
       {stageSummary.items.map((item, index) => (
         <SummaryItem
-          model={model}
-          modelPath={modelPath}
           key={`${item.type}/${index}`}
           item={item}
           stageSummary={stageSummary}

--- a/packages/query-composer/src/components/QuerySummaryPanel/SummaryItem.tsx
+++ b/packages/query-composer/src/components/QuerySummaryPanel/SummaryItem.tsx
@@ -13,7 +13,7 @@ import {
   StageSummary,
   stagePathPush,
 } from '../../types';
-import {ModelDef, SourceDef} from '@malloydata/malloy';
+import {SourceDef} from '@malloydata/malloy';
 import {StageSummaryUI} from './StateSummaryUI';
 import {FieldListDiv} from './FieldListDiv';
 import {HoverToPopover} from '../HoverToPopover';
@@ -46,13 +46,9 @@ export interface SummaryItemProps {
   isSelected: boolean;
   deselect: () => void;
   queryModifiers: QueryModifiers;
-  model: ModelDef;
-  modelPath: string;
 }
 
 export const SummaryItem: React.FC<SummaryItemProps> = ({
-  model,
-  modelPath,
   item,
   source,
   stagePath,
@@ -88,8 +84,6 @@ export const SummaryItem: React.FC<SummaryItemProps> = ({
         popoverContent={({closeMenu}) => {
           const baseMenuProps = {
             closeMenu,
-            model,
-            modelPath,
             source,
             stagePath,
             stageSummary,
@@ -383,8 +377,6 @@ export const SummaryItem: React.FC<SummaryItemProps> = ({
             stageIndex,
           });
           const baseProps = {
-            model,
-            modelPath,
             source: stageSummary.inputSource,
             stagePath: nestStagePath,
             stageSummary,
@@ -430,8 +422,6 @@ export const SummaryItem: React.FC<SummaryItemProps> = ({
             {children.map(({childItem, fieldIndex}, index) => {
               return (
                 <SummaryItem
-                  model={model}
-                  modelPath={modelPath}
                   key={'child:' + index}
                   item={childItem}
                   source={source}

--- a/packages/query-composer/src/components/Result/Result.tsx
+++ b/packages/query-composer/src/components/Result/Result.tsx
@@ -42,19 +42,16 @@ import {ActionIcon} from '../ActionIcon';
 import {ComposerOptionsContext} from '../ExploreQueryEditor/ExploreQueryEditor';
 import {highlightPre} from '../../highlight';
 import {QuerySummary} from '../../types';
+import {QueryWriter} from '../../core/query';
 
 type MalloyType = 'notebook' | 'model' | 'markdown' | 'source';
 
 interface ResultProps {
   model: malloy.ModelDef;
+  modelPath: string;
   source: malloy.StructDef;
   result?: malloy.Result;
-  malloy: {
-    source: string;
-    model: string;
-    markdown: string;
-    notebook: string;
-  };
+  queryWriter: QueryWriter;
   querySummary: QuerySummary | undefined;
   onDrill: (filters: malloy.FilterCondition[]) => void;
   isRunning: boolean;
@@ -62,10 +59,11 @@ interface ResultProps {
 
 export const Result: React.FC<ResultProps> = ({
   model,
+  modelPath,
+  queryWriter,
   querySummary,
   source,
   result,
-  malloy,
   onDrill,
   isRunning,
 }) => {
@@ -81,15 +79,33 @@ export const Result: React.FC<ResultProps> = ({
 
   const {isRunnable} = querySummary ?? {isRunnable: false};
 
+  const malloy = queryWriter.getQueryStringForNotebook();
+  let malloyPreview: string | undefined;
+  switch (malloyType) {
+    case 'markdown':
+      malloyPreview = queryWriter.getQueryStringForMarkdown(modelPath);
+      break;
+    case 'notebook':
+      malloyPreview = malloy;
+      break;
+    case 'source':
+      malloyPreview = queryWriter.getQueryStringForSource(
+        querySummary?.name ?? 'new_query'
+      );
+      break;
+    case 'model':
+      malloyPreview = queryWriter.getQueryStringForModel();
+      break;
+  }
+
   useEffect(() => {
     let canceled = false;
 
     const updateMalloy = async () => {
       try {
         const highlighter = malloyType === 'markdown' ? 'md' : 'malloy';
-        const source: string = malloy[malloyType];
 
-        const html = await highlightPre(source, highlighter);
+        const html = await highlightPre(malloyPreview ?? '', highlighter);
         if (!canceled) {
           setHighlightedSource(html);
         }
@@ -103,7 +119,7 @@ export const Result: React.FC<ResultProps> = ({
     return () => {
       canceled = true;
     };
-  }, [malloy, malloyType]);
+  }, [malloyPreview, malloyType]);
 
   useEffect(() => {
     let canceled = false;
@@ -113,8 +129,8 @@ export const Result: React.FC<ResultProps> = ({
         const getSQL = async (): Promise<string | undefined> => {
           if (result?.sql) {
             return result?.sql;
-          } else if (model && malloy.model && isRunnable) {
-            return dummyCompiler.compileQueryToSQL(model, malloy.model);
+          } else if (model && malloy && isRunnable) {
+            return dummyCompiler.compileQueryToSQL(model, malloy);
           } else {
             return undefined;
           }
@@ -267,7 +283,7 @@ export const Result: React.FC<ResultProps> = ({
               <ActionIcon
                 action="copy"
                 onClick={() => {
-                  let code = malloy[malloyType];
+                  let code = malloy || '';
                   if (malloyType === 'source') {
                     code = indentCode(code);
                   }

--- a/packages/query-composer/src/components/Result/Result.tsx
+++ b/packages/query-composer/src/components/Result/Result.tsx
@@ -41,6 +41,7 @@ import {SelectDropdown} from '../SelectDropdown';
 import {ActionIcon} from '../ActionIcon';
 import {ComposerOptionsContext} from '../ExploreQueryEditor/ExploreQueryEditor';
 import {highlightPre} from '../../highlight';
+import {QuerySummary} from '../../types';
 
 type MalloyType = 'notebook' | 'model' | 'markdown' | 'source';
 
@@ -53,14 +54,15 @@ interface ResultProps {
     model: string;
     markdown: string;
     notebook: string;
-    isRunnable: boolean;
   };
+  querySummary: QuerySummary | undefined;
   onDrill: (filters: malloy.FilterCondition[]) => void;
   isRunning: boolean;
 }
 
 export const Result: React.FC<ResultProps> = ({
   model,
+  querySummary,
   source,
   result,
   malloy,
@@ -76,6 +78,8 @@ export const Result: React.FC<ResultProps> = ({
   const [rendering, setRendering] = useState(false);
   const [malloyType, setMalloyType] = useState<MalloyType>('notebook');
   const [displaying, setDisplaying] = useState(false);
+
+  const {isRunnable} = querySummary ?? {isRunnable: false};
 
   useEffect(() => {
     let canceled = false;
@@ -109,7 +113,7 @@ export const Result: React.FC<ResultProps> = ({
         const getSQL = async (): Promise<string | undefined> => {
           if (result?.sql) {
             return result?.sql;
-          } else if (model && malloy.model && malloy.isRunnable) {
+          } else if (model && malloy.model && isRunnable) {
             return dummyCompiler.compileQueryToSQL(model, malloy.model);
           } else {
             return undefined;

--- a/packages/query-composer/src/components/Result/Result.tsx
+++ b/packages/query-composer/src/components/Result/Result.tsx
@@ -143,7 +143,7 @@ export const Result: React.FC<ResultProps> = ({
     return () => {
       canceled = true;
     };
-  }, [result, malloy, model, dummyCompiler]);
+  }, [result, malloy, model, dummyCompiler, isRunnable]);
 
   const drillCallback = useCallback(
     (_drillQuery: string, _target: HTMLElement, drillFilters: string[]) => {

--- a/packages/query-composer/src/components/StageActionMenu/StageActionMenu.tsx
+++ b/packages/query-composer/src/components/StageActionMenu/StageActionMenu.tsx
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 import * as React from 'react';
-import {SourceDef, ModelDef} from '@malloydata/malloy';
+import {SourceDef} from '@malloydata/malloy';
 import {OrderByField, StagePath, StageSummary} from '../../types';
 import {AggregateContextBar} from '../AggregateContextBar';
 import {GroupByContextBar} from '../GroupByContextBar';
@@ -47,8 +47,6 @@ interface StageActionMenuProps {
   closeMenu: () => void;
   stageSummary: StageSummary;
   isLastStage: boolean;
-  model: ModelDef;
-  modelPath: string;
   queryModifiers: QueryModifiers;
 }
 
@@ -59,8 +57,6 @@ export const StageActionMenu: React.FC<StageActionMenuProps> = ({
   closeMenu,
   stageSummary,
   isLastStage,
-  model,
-  modelPath,
   queryModifiers,
 }) => {
   return (
@@ -77,8 +73,6 @@ export const StageActionMenu: React.FC<StageActionMenuProps> = ({
           divider: stageSummary.type === 'project',
           Component: ({onComplete}: ActionSubmenuComponentProps) => (
             <FilterContextBar
-              model={model}
-              modelPath={modelPath}
               source={source}
               addFilter={(filter, as) =>
                 queryModifiers.addFilter(stagePath, filter, as)

--- a/packages/query-composer/src/components/TopQueryActionMenu/TopQueryActionMenu.tsx
+++ b/packages/query-composer/src/components/TopQueryActionMenu/TopQueryActionMenu.tsx
@@ -46,7 +46,6 @@ interface TopQueryActionMenuProps {
   orderByFields: OrderByField[];
   closeMenu: () => void;
   stageSummary: StageSummary | undefined;
-  queryName: string;
   isOnlyStage: boolean;
   queryModifiers: QueryModifiers;
   model: ModelDef;

--- a/packages/query-composer/src/components/TopQueryActionMenu/TopQueryActionMenu.tsx
+++ b/packages/query-composer/src/components/TopQueryActionMenu/TopQueryActionMenu.tsx
@@ -30,7 +30,7 @@ import {FilterContextBar} from '../FilterContextBar';
 import {AddLimit} from '../AddLimit';
 import {OrderByContextBar} from '../OrderByContextBar';
 import {ActionMenu, ActionSubmenuComponentProps} from '../ActionMenu';
-import {SourceDef, ModelDef} from '@malloydata/malloy';
+import {SourceDef} from '@malloydata/malloy';
 import {DataStyleContextBar} from '../DataStyleContextBar';
 import {
   fieldToSummaryItem,
@@ -48,8 +48,6 @@ interface TopQueryActionMenuProps {
   stageSummary: StageSummary | undefined;
   isOnlyStage: boolean;
   queryModifiers: QueryModifiers;
-  model: ModelDef;
-  modelPath: string;
 }
 
 export const TopQueryActionMenu: React.FC<TopQueryActionMenuProps> = ({
@@ -58,16 +56,12 @@ export const TopQueryActionMenu: React.FC<TopQueryActionMenuProps> = ({
   orderByFields,
   closeMenu,
   queryModifiers,
-  model,
-  modelPath,
 }) => {
   return (
     <ActionMenu
       valueSearchSource={source}
       addFilter={filter => queryModifiers.addFilter(stagePath, filter)}
       closeMenu={closeMenu}
-      model={model}
-      modelPath={modelPath}
       actions={[
         {
           kind: 'sub_menu',
@@ -78,8 +72,6 @@ export const TopQueryActionMenu: React.FC<TopQueryActionMenuProps> = ({
           closeOnComplete: true,
           Component: ({onComplete}: ActionSubmenuComponentProps) => (
             <FilterContextBar
-              modelPath={modelPath}
-              model={model}
               source={source}
               addFilter={(filter, as) =>
                 queryModifiers.addFilter(stagePath, filter, as)

--- a/packages/query-composer/src/core/fields.ts
+++ b/packages/query-composer/src/core/fields.ts
@@ -175,7 +175,7 @@ const MEASURE_AVG = /^(.*)\.avg\(\)$/;
 const MEASURE_SUM = /^(.*)\.sum\(\)$/;
 const MEASURE_MIN = /^min\((.*)\)/;
 const MEASURE_MAX = /^max\((.*)\)/;
-const MEASURE_PERCENT = /^100 \* (.*) \/ all\((.*)\)$/;
+const MEASURE_PERCENT = /^100 \* (.+) \/ all\((.+)\)$/;
 
 export function degenerateAggregate(
   source: SourceDef,

--- a/packages/query-composer/src/core/query.ts
+++ b/packages/query-composer/src/core/query.ts
@@ -219,21 +219,6 @@ export class QueryBuilder extends SourceUtils {
     return writer.getQueryStringForNotebook();
   }
 
-  public getQueryStrings(modelPath: string | undefined): {
-    model: string;
-    markdown: string;
-    source: string;
-    notebook: string;
-  } {
-    const writer = this.getWriter();
-    return {
-      model: writer.getQueryStringForModel(),
-      source: writer.getQueryStringForSource(this.query.name),
-      markdown: writer.getQueryStringForMarkdown(modelPath),
-      notebook: writer.getQueryStringForNotebook(),
-    };
-  }
-
   getName(): string {
     return this.query.name;
   }
@@ -1365,7 +1350,8 @@ ${malloy}
       return summary;
     });
     const isRunnable = this.canRun();
-    return {stages, isRunnable};
+    const name = this.query.as ?? this.query.name;
+    return {name, stages, isRunnable};
   }
 
   private nameOf(field: QueryFieldDef) {

--- a/packages/query-composer/src/core/query.ts
+++ b/packages/query-composer/src/core/query.ts
@@ -814,6 +814,10 @@ export class QueryBuilder extends SourceUtils {
     }
   }
 
+  canRun() {
+    return this.getWriter().canRun();
+  }
+
   renameField(stagePath: StagePath, fieldIndex: number, as: string): void {
     const stage = this.stageAtPath(stagePath);
     const fields = getFields(stage);

--- a/packages/query-composer/src/data/use_run_query.ts
+++ b/packages/query-composer/src/data/use_run_query.ts
@@ -26,14 +26,13 @@ import {useCallback, useState} from 'react';
 export type RunQuery = (
   query: string,
   model: malloy.ModelDef,
-  modelPath: string,
-  queryName: string
+  modelPath: string
 ) => Promise<malloy.Result>;
 
 export interface UseRunQueryResult {
   result: malloy.Result | undefined;
   error: Error | undefined;
-  runQuery: (query: string, queryName: string) => void;
+  runQuery: (query: string) => void;
   reset: () => void;
   isRunning: boolean;
 }
@@ -54,14 +53,14 @@ export function useRunQuery(
   }, []);
 
   const runQuery = useCallback(
-    (query: string, queryName: string) => {
+    (query: string) => {
       reset();
       if (!model || !modelPath) {
         setError(new Error('No model'));
         return;
       }
       setIsRunning(true);
-      runQueryImp(query, model, modelPath, queryName)
+      runQueryImp(query, model, modelPath)
         .then(result => {
           setResult(result);
         })

--- a/packages/query-composer/src/data/use_run_query.ts
+++ b/packages/query-composer/src/data/use_run_query.ts
@@ -26,13 +26,14 @@ import {useCallback, useState} from 'react';
 export type RunQuery = (
   query: string,
   model: malloy.ModelDef,
-  modelPath: string
+  modelPath: string,
+  queryName?: string
 ) => Promise<malloy.Result>;
 
 export interface UseRunQueryResult {
   result: malloy.Result | undefined;
   error: Error | undefined;
-  runQuery: (query: string) => void;
+  runQuery: (query: string, queryName?: string) => void;
   reset: () => void;
   isRunning: boolean;
 }
@@ -53,14 +54,14 @@ export function useRunQuery(
   }, []);
 
   const runQuery = useCallback(
-    (query: string) => {
+    (query: string, queryName?: string) => {
       reset();
       if (!model || !modelPath) {
         setError(new Error('No model'));
         return;
       }
       setIsRunning(true);
-      runQueryImp(query, model, modelPath)
+      runQueryImp(query, model, modelPath, queryName)
         .then(result => {
           setResult(result);
         })

--- a/packages/query-composer/src/data/use_search.ts
+++ b/packages/query-composer/src/data/use_search.ts
@@ -5,14 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {ModelDef, SearchIndexResult, StructDef} from '@malloydata/malloy';
+import {SearchIndexResult} from '@malloydata/malloy';
 import {SearchContext} from '../contexts/search_context';
 import {useContext} from 'react';
 
 export function useSearch(
-  _model: ModelDef | undefined,
-  _modelPath: string | undefined,
-  _source: StructDef | undefined,
   searchTerm: string,
   fieldPath?: string
 ): {searchResults: SearchIndexResult[] | undefined; isLoading: boolean} {

--- a/packages/query-composer/src/hooks/use_query_builder.ts
+++ b/packages/query-composer/src/hooks/use_query_builder.ts
@@ -40,7 +40,6 @@ export interface UseQueryBuilderResult {
     source: string;
     markdown: string;
     notebook: string;
-    isRunnable: boolean;
   };
   queryName: string;
   queryModifiers: QueryModifiers;

--- a/packages/query-composer/src/index.ts
+++ b/packages/query-composer/src/index.ts
@@ -1,5 +1,13 @@
-export {ExploreQueryEditor} from './components/ExploreQueryEditor/ExploreQueryEditor';
-export {QuerySummaryPanel} from './components/QuerySummaryPanel/QuerySummaryPanel';
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export {ExploreQueryEditor} from './components/ExploreQueryEditor';
+export {QueryEditor} from './components/QueryEditor';
+export {QuerySummaryPanel} from './components/QuerySummaryPanel';
 export {DummyCompile} from './core/dummy-compile';
 
 export {useRunQuery} from './data/use_run_query';

--- a/packages/query-composer/src/index.ts
+++ b/packages/query-composer/src/index.ts
@@ -8,6 +8,7 @@
 export {ExploreQueryEditor} from './components/ExploreQueryEditor';
 export {QueryEditor} from './components/QueryEditor';
 export {QuerySummaryPanel} from './components/QuerySummaryPanel';
+export {Result} from './components/Result';
 export {DummyCompile} from './core/dummy-compile';
 
 export {useRunQuery} from './data/use_run_query';

--- a/packages/query-composer/src/types.ts
+++ b/packages/query-composer/src/types.ts
@@ -209,6 +209,7 @@ export interface StageSummary {
 
 export interface QuerySummary {
   stages: StageSummary[];
+  isRunnable: boolean;
 }
 
 export interface StagePath {

--- a/packages/query-composer/src/types.ts
+++ b/packages/query-composer/src/types.ts
@@ -208,6 +208,7 @@ export interface StageSummary {
 }
 
 export interface QuerySummary {
+  name: string;
   stages: StageSummary[];
   isRunnable: boolean;
 }

--- a/packages/query-composer/tests/hooks/use_query_builder.spec.ts
+++ b/packages/query-composer/tests/hooks/use_query_builder.spec.ts
@@ -42,15 +42,17 @@ describe('useQueryBuilder', () => {
       }
     );
 
-    const {error, queryMalloy} = result.current;
+    const {error, querySummary, queryWriter} = result.current;
+    const queryMalloy = queryWriter.getQueryStringForNotebook();
 
     expect(error).toBe(undefined);
-    expect(queryMalloy).toEqual(
+    expect(querySummary).toEqual(
       expect.objectContaining({
+        name: 'new_query',
         isRunnable: false,
-        source: 'view: new_query is {\n}',
       })
     );
+    expect(queryMalloy).toEqual('run: names -> {\n}');
   });
 
   it('supports modification', () => {
@@ -72,19 +74,21 @@ describe('useQueryBuilder', () => {
 
     rerender({args: [model, 'names', 'names.malloy', undefined]});
 
-    const {error, queryMalloy} = result.current;
+    const {error, querySummary, queryWriter} = result.current;
+    const queryMalloy = queryWriter.getQueryStringForNotebook();
 
     expect(error).toBe(undefined);
-    expect(queryMalloy).toEqual(
+    expect(querySummary).toEqual(
       expect.objectContaining({
+        name: 'new_query',
         isRunnable: true,
-        source: `\
-view: new_query is {
-  group_by: abc is decade
-  limit: 10
-}`,
       })
     );
+    expect(queryMalloy).toEqual(`\
+run: names -> {
+  group_by: abc is decade
+  limit: 10
+}`);
   });
 
   describe('updating the model', () => {
@@ -108,19 +112,21 @@ view: new_query is {
       const newModel = structuredClone(model);
       rerender({args: [newModel, 'names', 'names.malloy', undefined]});
 
-      const {error, queryMalloy} = result.current;
+      const {error, querySummary, queryWriter} = result.current;
+      const queryMalloy = queryWriter.getQueryStringForNotebook();
 
       expect(error).toBe(undefined);
-      expect(queryMalloy).toEqual(
+      expect(querySummary).toEqual(
         expect.objectContaining({
+          name: 'new_query',
           isRunnable: true,
-          source: `\
-view: new_query is {
-  group_by: abc is decade
-  limit: 10
-}`,
         })
       );
+      expect(queryMalloy).toEqual(`\
+run: names -> {
+  group_by: abc is decade
+  limit: 10
+}`);
     });
 
     it('clears the query when a new source is incompatible', () => {
@@ -142,15 +148,17 @@ view: new_query is {
 
       rerender({args: [model, 'cohort', 'names.malloy', undefined]});
 
-      const {error, queryMalloy} = result.current;
+      const {error, querySummary, queryWriter} = result.current;
+      const queryMalloy = queryWriter.getQueryStringForNotebook();
 
       expect(error).toBe(undefined);
-      expect(queryMalloy).toEqual(
+      expect(querySummary).toEqual(
         expect.objectContaining({
-          isRunnable: false,
-          source: '',
+          name: 'new_query',
+          isRunnable: true,
         })
       );
+      expect(queryMalloy).toEqual('run: cohort -> {\n}');
     });
   });
 });

--- a/src/app/CommonElements.tsx
+++ b/src/app/CommonElements.tsx
@@ -27,7 +27,7 @@ export const EmptyMessage = styled.div`
   text-align: center;
   margin-top: 30px;
   margin-bottom: 30px;
-  font-family: Roboto;
+  font-family: var(--malloy-composer-fontFamily, sans-serif);
   text-transform: none;
   font-size: 16px;
   font-weight: normal;

--- a/src/app/Explore/Explore.tsx
+++ b/src/app/Explore/Explore.tsx
@@ -136,10 +136,6 @@ export const Explore: React.FC = () => {
   } = useRunQuery(modelDef, modelPath, runQueryExt);
 
   useEffect(() => {
-    reset();
-  }, [querySummary, reset]);
-
-  useEffect(() => {
     if (builderError) {
       setError(builderError);
     } else if (runnerError) {
@@ -322,16 +318,6 @@ export const Explore: React.FC = () => {
   };
 
   const topValues = useTopValues(modelDef, modelPath, sourceDef);
-  if (loading || (appId && !appInfo)) {
-    section = 'loading';
-  }
-
-  // eslint-disable-next-line no-console
-  console.log({
-    model,
-    modelPath,
-    source,
-  });
 
   return (
     <Main handlers={handlers} keyMap={KEY_MAP}>
@@ -427,10 +413,10 @@ export const Explore: React.FC = () => {
                   <Apps />
                 </PageContent>
               )}
-              {section === 'loading' && (
-                <EmptyMessage>
+              {loading && (
+                <LoadingOverlay>
                   <LoadingSpinner text="Loading Data..." />
-                </EmptyMessage>
+                </LoadingOverlay>
               )}
             </PageContainer>
           </Page>
@@ -519,6 +505,7 @@ const HeaderLeft = styled.div`
 const Page = styled(Content)`
   margin-top: 10px;
   height: unset;
+  position: relative;
 `;
 
 const RightChannel = styled.div`
@@ -537,6 +524,17 @@ const BottomChannel = styled.div`
   display: flex;
   flex-direction: column;
   background-color: ${COLORS.mainBackground};
+`;
+
+const LoadingOverlay = styled(EmptyMessage)`
+  background-color: ${COLORS.mainBackground};
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 9999;
+  margin: 0;
 `;
 
 function generateReadme(appInfo: AppInfo) {

--- a/src/app/Explore/Explore.tsx
+++ b/src/app/Explore/Explore.tsx
@@ -137,6 +137,10 @@ export const Explore: React.FC = () => {
   } = useRunQuery(modelDef, modelPath, runQueryExt);
 
   useEffect(() => {
+    reset();
+  }, [querySummary, reset]);
+
+  useEffect(() => {
     if (builderError) {
       setError(builderError);
     } else if (runnerError) {

--- a/src/app/Explore/Explore.tsx
+++ b/src/app/Explore/Explore.tsx
@@ -202,7 +202,7 @@ export const Explore: React.FC = () => {
             );
             queryModifiers.setQuery(compiledQuery, true);
             if (run === 'true' && page === 'query') {
-              runQuery(urlQuery);
+              runQuery(urlQuery, name || 'unnamed');
             }
           } else {
             urlParams.delete('query');
@@ -308,7 +308,7 @@ export const Explore: React.FC = () => {
   const runQueryAction = () => {
     const query = queryWriter.getQueryStringForNotebook();
     if (query) {
-      runQuery(query);
+      runQuery(query, querySummary?.name);
     }
   };
 

--- a/src/app/data/duckdb_wasm.ts
+++ b/src/app/data/duckdb_wasm.ts
@@ -175,7 +175,6 @@ export async function datasets(appRoot: string): Promise<explore.AppInfo> {
 
 export async function runQuery(
   query: string,
-  queryName: string,
   model: malloy.ModelDef
 ): Promise<Error | malloy.Result> {
   const baseModel = await RUNTIME._loadModelFromModelDef(model).getModel();

--- a/src/app/data/run_query.ts
+++ b/src/app/data/run_query.ts
@@ -12,7 +12,8 @@ import * as duckDBWASM from './duckdb_wasm';
 export async function runQuery(
   query: string,
   model: malloy.ModelDef,
-  modelPath: string
+  modelPath: string,
+  queryName?: string
 ): Promise<malloy.Result> {
   if (isDuckDBWASM()) {
     const result = await duckDBWASM.runQuery(query, model);
@@ -31,6 +32,7 @@ export async function runQuery(
       body: JSON.stringify({
         query,
         modelPath,
+        queryName,
       }),
     })
   ).json();

--- a/src/app/data/run_query.ts
+++ b/src/app/data/run_query.ts
@@ -12,11 +12,10 @@ import * as duckDBWASM from './duckdb_wasm';
 export async function runQuery(
   query: string,
   model: malloy.ModelDef,
-  modelPath: string,
-  queryName: string
+  modelPath: string
 ): Promise<malloy.Result> {
   if (isDuckDBWASM()) {
-    const result = await duckDBWASM.runQuery(query, queryName, model);
+    const result = await duckDBWASM.runQuery(query, model);
     if (result instanceof Error) {
       throw result;
     }
@@ -32,7 +31,6 @@ export async function runQuery(
       body: JSON.stringify({
         query,
         modelPath,
-        queryName,
       }),
     })
   ).json();

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -50,11 +50,10 @@ export function routes(router: express.Router): void {
     '/run_query',
     async (req: express.Request, res: express.Response) => {
       const query = req.body.query as string;
-      const queryName = req.body.queryName as string;
       const modelPath = req.body.modelPath as string;
       res.json(
         await wrapErrors(async () => {
-          const result = await runQuery(query, queryName, modelPath);
+          const result = await runQuery(query, modelPath);
           return {result: result.toJSON()};
         })
       );

--- a/src/server/run_query.ts
+++ b/src/server/run_query.ts
@@ -29,7 +29,6 @@ import {getConfig} from './config';
 
 export async function runQuery(
   query: string,
-  queryName: string,
   modelPath: string
 ): Promise<Result> {
   const {workingDirectory} = await getConfig();


### PR DESCRIPTION
* Split query builder and result panel into separate components. 
* Clean up API from useQueryBuilder() to remove easily derived values. 
* Clean up some no longer necessary prop-drilling. 
* Stop unmounting underlying panes when loading