### PR TITLE
Add support for mouse click modifiers

### DIFF
--- a/packages/query-composer/src/components/ActionMenu/ActionMenu.tsx
+++ b/packages/query-composer/src/components/ActionMenu/ActionMenu.tsx
@@ -51,7 +51,7 @@ interface ActionBase {
 
 interface OneClickAction extends ActionBase {
   kind: 'one_click';
-  onClick: () => void;
+  onClick: (event: React.MouseEvent) => void;
 }
 
 export interface ActionSubmenuComponentProps {
@@ -129,9 +129,9 @@ export const ActionMenu: React.FC<ActionMenuProps> = ({
                         <ActionButton
                           key={action.id}
                           color={action.iconColor}
-                          onClick={() => {
+                          onClick={event => {
                             if (action.kind === 'one_click') {
-                              action.onClick();
+                              action.onClick(event);
                               closeMenu();
                             } else {
                               setActiveAction(action);

--- a/packages/query-composer/src/components/CommonElements.tsx
+++ b/packages/query-composer/src/components/CommonElements.tsx
@@ -129,7 +129,7 @@ export const ButtonAndInputRow = styled.form`
 `;
 
 interface ChevronButtonProps {
-  onClick: () => void;
+  onClick: (event: React.MouseEvent) => void;
 }
 
 export const ChevronLeftButton: React.FC<ChevronButtonProps> = ({onClick}) => {

--- a/packages/query-composer/src/components/FieldButton/FieldButton.tsx
+++ b/packages/query-composer/src/components/FieldButton/FieldButton.tsx
@@ -29,7 +29,7 @@ import {FieldName, FieldIcon} from '../CommonElements';
 
 interface FieldButtonProps {
   icon: ReactElement;
-  onClick?: () => void;
+  onClick?: (event: React.MouseEvent) => void;
   canRemove?: boolean;
   onRemove?: () => void;
   name: string;

--- a/packages/query-composer/src/components/FieldList/FieldList.tsx
+++ b/packages/query-composer/src/components/FieldList/FieldList.tsx
@@ -31,13 +31,18 @@ import {HoverToPopover} from '../HoverToPopover';
 import {ListNest} from '../ListNest';
 import {TypeIcon} from '../TypeIcon';
 import {kindOfField, typeOfField} from '../../utils';
+import {EventModifiers} from '../component_types';
 
-interface FieldListProps {
+export interface FieldListProps {
   path?: string[];
   fields: FieldDef[];
   filter: (field: FieldDef) => boolean;
   showNested: boolean;
-  selectField: (fieldPath: string, field: FieldDef) => void;
+  selectField: (
+    fieldPath: string,
+    field: FieldDef,
+    modifiers: EventModifiers
+  ) => void;
 }
 
 export const FieldList: React.FC<FieldListProps> = ({
@@ -63,7 +68,15 @@ export const FieldList: React.FC<FieldListProps> = ({
                 content={() => (
                   <FieldButton
                     icon={<TypeIcon type={type} kind={kind} />}
-                    onClick={() => selectField(fieldPath, field)}
+                    onClick={event => {
+                      const {altKey, ctrlKey, metaKey, shiftKey} = event;
+                      selectField(fieldPath, field, {
+                        altKey,
+                        ctrlKey,
+                        metaKey,
+                        shiftKey,
+                      });
+                    }}
                     name={field.as || field.name}
                     color={kind}
                   />
@@ -111,7 +124,11 @@ interface CollapsibleSourceProps {
   path: string[];
   source: StructDef;
   filter: (field: FieldDef) => boolean;
-  selectField: (fieldPath: string, field: FieldDef) => void;
+  selectField: (
+    fieldPath: string,
+    field: FieldDef,
+    modifiers: EventModifiers
+  ) => void;
 }
 
 const CollapsibleSource: React.FC<CollapsibleSourceProps> = ({

--- a/packages/query-composer/src/components/LoadTopQueryContextBar/LoadTopQueryContextBar.tsx
+++ b/packages/query-composer/src/components/LoadTopQueryContextBar/LoadTopQueryContextBar.tsx
@@ -47,11 +47,12 @@ import {
   pathParent,
   termsForField,
 } from '../../utils';
+import {EventModifiers} from '../component_types';
 
 interface LoadTopQueryContextBarProps {
   model: ModelDef | undefined;
   source: StructDef;
-  selectField: (field: FieldDef) => void;
+  selectField: (field: FieldDef, modifiers: EventModifiers) => void;
   onComplete: () => void;
 }
 
@@ -85,8 +86,8 @@ export const LoadTopQueryContextBar: React.FC<LoadTopQueryContextBarProps> = ({
               fields={fields}
               filter={field => field.type === 'turtle'}
               showNested={true}
-              selectField={(_, fieldDef) => {
-                selectField(fieldDef);
+              selectField={(_, fieldDef, modifiers) => {
+                selectField(fieldDef, modifiers);
                 onComplete();
               }}
             />
@@ -102,8 +103,8 @@ export const LoadTopQueryContextBar: React.FC<LoadTopQueryContextBarProps> = ({
                     terms: [...termsForField(field, path), 'query'],
                     detail: pathParent(path),
                     key: keyFor(path),
-                    select: () => {
-                      selectField(field);
+                    select: (field, modifiers: EventModifiers) => {
+                      selectField(field, modifiers);
                       onComplete();
                     },
                   }))}

--- a/packages/query-composer/src/components/QueryEditor/QueryEditor.tsx
+++ b/packages/query-composer/src/components/QueryEditor/QueryEditor.tsx
@@ -19,8 +19,6 @@ import styled from 'styled-components';
 import {SearchContext} from '../../contexts/search_context';
 import {QueryWriter} from '../../core/query';
 
-const useLoad = true;
-
 export interface QueryEditorProps {
   isRunning: boolean;
   model: ModelDef;
@@ -115,8 +113,8 @@ export const QueryEditor = ({
                   <LoadTopQueryContextBar
                     model={model}
                     source={source}
-                    selectField={field =>
-                      useLoad
+                    selectField={(field, {shiftKey}) =>
+                      shiftKey
                         ? loadQuery(field.as || field.name)
                         : replaceQuery(field as TurtleDef)
                     }

--- a/packages/query-composer/src/components/SearchList/SearchList.tsx
+++ b/packages/query-composer/src/components/SearchList/SearchList.tsx
@@ -22,16 +22,18 @@
  */
 import * as React from 'react';
 import styled from 'styled-components';
-import {QuerySummaryItem, QuerySummaryItemField} from '../../types';
+import {FieldDef} from '@malloydata/malloy';
+import {QuerySummaryItem} from '../../types';
 import {EmptyMessage} from '../CommonElements';
 import {FieldButton} from '../FieldButton';
 import {FieldDetailPanel} from '../FieldDetailPanel';
 import {HoverToPopover} from '../HoverToPopover';
 import {TypeIcon} from '../TypeIcon';
 import {typeOfField} from '../../utils';
+import {EventModifiers} from '../component_types';
 
 export interface SearchItem {
-  select: () => void;
+  select: (field: FieldDef, modifiers: EventModifiers) => void;
   item: QuerySummaryItem;
   detail?: string;
   terms: string[];
@@ -63,7 +65,7 @@ export const useSearchList = ({
     <ListDiv>
       {rankedItems.map(({item}) => {
         if (item.item.type === 'field') {
-          const field = item.item as QuerySummaryItemField;
+          const field = item.item;
           const type = typeOfField(item.item.field);
           return (
             <HoverToPopover
@@ -72,7 +74,15 @@ export const useSearchList = ({
               content={() => (
                 <FieldButton
                   icon={<TypeIcon type={type} kind={field.kind} />}
-                  onClick={item.select}
+                  onClick={event => {
+                    const {altKey, ctrlKey, metaKey, shiftKey} = event;
+                    item.select(field.field, {
+                      altKey,
+                      ctrlKey,
+                      metaKey,
+                      shiftKey,
+                    });
+                  }}
                   name={field.name}
                   color={field.kind}
                   detail={item.detail}

--- a/packages/query-composer/src/components/component_types.ts
+++ b/packages/query-composer/src/components/component_types.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export interface EventModifiers {
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+}

--- a/src/app/ChannelButton/ChannelButton.tsx
+++ b/src/app/ChannelButton/ChannelButton.tsx
@@ -28,7 +28,7 @@ import {ChannelIcon, ChannelIconName} from '../ChannelIcon';
 export const ChannelButton: React.FC<{
   icon: ChannelIconName;
   text: string;
-  onClick: () => void;
+  onClick: (event: React.MouseEvent) => void;
   selected: boolean;
   disabled?: boolean;
 }> = ({icon, text, onClick, selected, disabled = false}) => {


### PR DESCRIPTION
Now shift-click on a turtle merges with, not replaces, the existing query.