### PR TITLE
Allow refreshing top values

### DIFF
--- a/packages/query-composer/src/components/ActionIcon/ActionIcon.tsx
+++ b/packages/query-composer/src/components/ActionIcon/ActionIcon.tsx
@@ -84,7 +84,7 @@ export type ActionIconName =
 
 interface ActionIconProps {
   action: ActionIconName;
-  onClick?: () => void;
+  onClick?: (event: React.MouseEvent) => void;
   color?: ColorKey;
   title?: string;
 }

--- a/packages/query-composer/src/components/ExploreQueryEditor/ExploreQueryEditor.tsx
+++ b/packages/query-composer/src/components/ExploreQueryEditor/ExploreQueryEditor.tsx
@@ -22,6 +22,7 @@ import {QueryEditor} from '../QueryEditor';
 import {QueryWriter} from '../../core/query';
 import {ComposerOptionsContext} from '../../contexts';
 import {StubCompile} from '../../core/stub-compile';
+import {EventModifiers} from '../component_types';
 
 interface ExploreQueryEditorProps {
   source: SourceDef;
@@ -30,7 +31,7 @@ interface ExploreQueryEditorProps {
   querySummary: QuerySummary | undefined;
   queryModifiers: QueryModifiers;
   runQuery: (query: string, queryName?: string) => void;
-  refreshModel?: () => void;
+  refreshModel?: (modifiers: EventModifiers) => void;
   isRunning: boolean;
   result: MalloyResult | Error | undefined;
   model: ModelDef;

--- a/packages/query-composer/src/components/QueryEditor/QueryEditor.tsx
+++ b/packages/query-composer/src/components/QueryEditor/QueryEditor.tsx
@@ -8,6 +8,7 @@ import {
   TurtleDef,
 } from '@malloydata/malloy';
 import {ActionIcon} from '../ActionIcon';
+import {EventModifiers} from '../component_types';
 import {PageContent, PageHeader} from '../CommonElements';
 import {LoadTopQueryContextBar} from '../LoadTopQueryContextBar';
 import {Popover} from '../Popover';
@@ -22,7 +23,7 @@ import {QueryWriter} from '../../core/query';
 export interface QueryEditorProps {
   isRunning: boolean;
   model: ModelDef;
-  refreshModel?: () => void;
+  refreshModel?: (modifiers: EventModifiers) => void;
   queryModifiers: QueryModifiers;
   querySummary: QuerySummary | undefined;
   queryWriter: QueryWriter;
@@ -80,7 +81,10 @@ export const QueryEditor = ({
                 {refreshModel && (
                   <ActionIcon
                     action="refresh"
-                    onClick={() => refreshModel()}
+                    onClick={event => {
+                      const {altKey, ctrlKey, metaKey, shiftKey} = event;
+                      refreshModel({altKey, ctrlKey, metaKey, shiftKey});
+                    }}
                     color="dimension"
                   />
                 )}

--- a/packages/query-composer/src/index.ts
+++ b/packages/query-composer/src/index.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+export type {EventModifiers} from './components/component_types';
 export {ExploreQueryEditor} from './components/ExploreQueryEditor';
 export {QueryEditor} from './components/QueryEditor';
 export {QuerySummaryPanel} from './components/QuerySummaryPanel';

--- a/src/app/Explore/Explore.tsx
+++ b/src/app/Explore/Explore.tsx
@@ -29,8 +29,9 @@ import {EmptyMessage, PageContent} from '../CommonElements';
 import {ChannelButton} from '../ChannelButton';
 import {HotKeys} from 'react-hotkeys';
 import {
-  StubCompile,
+  EventModifiers,
   ExploreQueryEditor,
+  StubCompile,
   useQueryBuilder,
   useRunQuery,
 } from '@malloydata/query-composer';
@@ -64,7 +65,7 @@ export const Explore: React.FC = () => {
   const app = onlyDefaultDataset
     ? config.apps[0]
     : config?.apps?.find(app => app.id === appId);
-  const {appInfo, refresh} = useDatasets(app);
+  const {appInfo, refresh: refreshModel} = useDatasets(app);
 
   // URL Parameter values
   const [urlParams, setParams] = useSearchParams();
@@ -319,7 +320,21 @@ export const Explore: React.FC = () => {
     RUN_QUERY: runQueryAction,
   };
 
-  const topValues = useTopValues(modelDef, modelPath, sourceDef);
+  const {topValues, refresh: refreshTopValues} = useTopValues(
+    modelDef,
+    modelPath,
+    sourceDef
+  );
+
+  const refresh = useCallback(
+    ({shiftKey}: EventModifiers) => {
+      refreshModel();
+      if (shiftKey) {
+        refreshTopValues();
+      }
+    },
+    [refreshModel, refreshTopValues]
+  );
 
   return (
     <Main handlers={handlers} keyMap={KEY_MAP}>

--- a/src/app/data/use_top_values.ts
+++ b/src/app/data/use_top_values.ts
@@ -25,6 +25,7 @@ import {ModelDef, SearchValueMapResult, StructDef} from '@malloydata/malloy';
 import {useQuery} from 'react-query';
 import {isDuckDBWASM} from '../utils';
 import * as duckDBWASM from './duckdb_wasm';
+import {useCallback} from 'react';
 
 async function fetchTopValues(
   model?: ModelDef,
@@ -58,8 +59,8 @@ export function useTopValues(
   model?: ModelDef,
   modelPath?: string,
   source?: StructDef
-): SearchValueMapResult[] | undefined {
-  const {data: models} = useQuery(
+): {refresh: () => void; topValues: SearchValueMapResult[] | undefined} {
+  const {data: topValues, refetch} = useQuery(
     ['top_values', modelPath, source?.name],
     () => fetchTopValues(model, modelPath, source),
     {
@@ -67,5 +68,9 @@ export function useTopValues(
     }
   );
 
-  return models;
+  const refresh = useCallback(() => {
+    refetch();
+  }, [refetch]);
+
+  return {refresh, topValues};
 }


### PR DESCRIPTION
Top values can change as the model changes, so allow refreshing top values by shift-clicking refresh.