### PR TITLE
sync querySummary and queryBuilder

### DIFF
--- a/packages/query-composer/src/hooks/use_query_builder.ts
+++ b/packages/query-composer/src/hooks/use_query_builder.ts
@@ -152,6 +152,10 @@ export function useQueryBuilder(
     console.info('> sourceDef changed');
   }, [sourceDef]);
 
+  useEffect(() => {
+    setQuerySummary(queryBuilder.getQuerySummary())
+  }, [queryBuilder, setQuerySummary])
+
   const modifyQuery = useCallback(
     (modify: (queryBuilder: QueryBuilder) => void, noURLUpdate = false) => {
       query.current = structuredClone(queryBuilder.getQuery());
@@ -186,7 +190,6 @@ export function useQueryBuilder(
 
   const queryModifiers = useMemo(() => {
     const clearQuery = (noURLUpdate = false) => {
-      if (queryBuilder.isEmpty()) return;
       modifyQuery(qb => {
         qb.clearQuery();
       }, noURLUpdate);

--- a/packages/query-composer/src/hooks/use_query_builder.ts
+++ b/packages/query-composer/src/hooks/use_query_builder.ts
@@ -153,8 +153,8 @@ export function useQueryBuilder(
   }, [sourceDef]);
 
   useEffect(() => {
-    setQuerySummary(queryBuilder.getQuerySummary())
-  }, [queryBuilder, setQuerySummary])
+    setQuerySummary(queryBuilder.getQuerySummary());
+  }, [queryBuilder, setQuerySummary]);
 
   const modifyQuery = useCallback(
     (modify: (queryBuilder: QueryBuilder) => void, noURLUpdate = false) => {

--- a/packages/query-composer/src/hooks/use_query_builder.ts
+++ b/packages/query-composer/src/hooks/use_query_builder.ts
@@ -386,7 +386,7 @@ export function useQueryBuilder(
       clearQuery,
       onDrill,
     };
-  }, [modifyQuery, queryBuilder, updateQueryInURL]);
+  }, [modifyQuery, updateQueryInURL]);
 
   useEffect(() => {
     console.info('> modifyQuery changed');

--- a/packages/query-composer/tests/hooks/use_query_builder.spec.ts
+++ b/packages/query-composer/tests/hooks/use_query_builder.spec.ts
@@ -156,9 +156,11 @@ run: names -> {
       expect(querySummary).toEqual(
         expect.objectContaining({
           name: 'new_query',
-          isRunnable: true,
+          isRunnable: false,
         })
       );
+      expect(querySummary?.stages).toHaveLength(1);
+      expect(querySummary?.stages?.[0].items).toHaveLength(0);
       expect(queryMalloy).toEqual('run: cohort -> {\n}');
       expect(warnSpy).toHaveBeenCalledWith(
         'Discarding query',


### PR DESCRIPTION
querySummary needs to:
1. be kept in sync with queryBuilder.getQuerySummary()
2. be memoized for downstream use